### PR TITLE
Auto-hydrate data list in collection resource

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -18,6 +18,8 @@ Changed
 * Auto-add 'output' prefix to ``field_name`` parameter for
   downloading files
 * Auto-wrapp ``list:*`` fields into list if they are not already
+* Data objects in ``data`` field on collection resource are
+  automatically hydrated
 
 
 ==================

--- a/resdk/tests/unit/test_collections.py
+++ b/resdk/tests/unit/test_collections.py
@@ -27,6 +27,24 @@ class TestBaseCollection(unittest.TestCase):
         collection_mock.configure_mock(endpoint="fake_endpoint")
         BaseCollection.__init__(collection_mock, id=1, resolwe=MagicMock())
 
+    def test_data(self):
+        collection = Collection(id=1, resolwe=MagicMock())
+
+        # test setting data attribute
+        collection.data = [1, 2, 3]
+        self.assertEqual(collection._data, [1, 2, 3])
+        self.assertEqual(collection._data_hydrated, False)
+
+        # test getting data attribute
+        collection.resolwe.data.filter = MagicMock(return_value=['data_1', 'data_2', 'data_3'])
+        self.assertEqual(collection.data, ['data_1', 'data_2', 'data_3'])
+        self.assertEqual(collection._data_hydrated, True)
+
+        # test caching data attribute
+        self.assertEqual(collection.data, ['data_1', 'data_2', 'data_3'])
+        self.assertEqual(collection._data_hydrated, True)
+        self.assertEqual(collection.resolwe.data.filter.call_count, 1)
+
     @patch('resdk.resources.collection.BaseCollection', spec=True)
     def test_data_types(self, collection_mock):
         get_mock = MagicMock(**{'get.return_value': DATA_SAMPLE[0]})


### PR DESCRIPTION
Method used for hydration is not optimal at the moment (it would be better to reload collection with `?hydrate_data=1` and manually generate list of Data objects), but enables some nice features in the future when queries will be lazy and compossible, i.e.: `collection.data.filter(type='data:differential-expression')` will load only DE objects

TODO:
- [x] write tests