### PR TITLE
Add knowledge base feature/mapping lookup

### DIFF
--- a/resdk/resolwe.py
+++ b/resdk/resolwe.py
@@ -27,7 +27,7 @@ from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
 from .exceptions import handle_http_exception, ValidationError
 from .resources import Data, Collection, Sample, Process
-from .resources.kb import Feature
+from .resources.kb import Feature, Mapping
 from .resources.utils import (
     iterate_fields, iterate_schema, endswith_colon, get_collection_id, get_data_id)
 from .query import ResolweQuery
@@ -82,6 +82,7 @@ class Resolwe(object):
         self.presample = ResolweQuery(self, Sample, endpoint='presample')
         self.process = ResolweQuery(self, Process)
         self.feature = ResolweQuery(self, Feature)
+        self.mapping = ResolweQuery(self, Mapping)
 
         self.logger = logging.getLogger(__name__)
 

--- a/resdk/resources/base.py
+++ b/resdk/resources/base.py
@@ -24,6 +24,8 @@ class BaseResource(object):
     """
 
     endpoint = None
+    query_endpoint = None
+    query_method = 'GET'
 
     WRITABLE_FIELDS = ('slug', 'name', 'permissions')
     UPDATE_PROTECTED_FIELDS = ('contributor', )

--- a/resdk/resources/kb/__init__.py
+++ b/resdk/resources/kb/__init__.py
@@ -10,8 +10,15 @@ Resource classes
 .. autoclass:: resdk.resources.kb.Feature
    :members:
 
+.. autoclass:: resdk.resources.kb.Mapping
+   :members:
+
 """
 
 from .feature import Feature
+from .mapping import Mapping
 
-__all__ = ('Feature',)
+__all__ = (
+    'Feature',
+    'Mapping',
+)

--- a/resdk/resources/kb/feature.py
+++ b/resdk/resources/kb/feature.py
@@ -8,3 +8,15 @@ class Feature(BaseResource):
     """Knowledge base Feature resource."""
 
     endpoint = 'kb.feature.admin'
+    query_endpoint = 'kb.feature.search'
+    query_method = 'POST'
+
+    WRITABLE_FIELDS = ('source', 'feature_id', 'species', 'type', 'sub_type', 'name',
+                       'full_name', 'description', 'aliases')
+    UPDATE_PROTECTED_FIELDS = ('source', 'feature_id')
+    READ_ONLY_FIELDS = ('id',)
+
+    def __repr__(self):
+        """Format feature representation."""
+        # pylint: disable=no-member
+        return "<Feature source='{}' feature_id='{}'>".format(self.source, self.feature_id)

--- a/resdk/resources/kb/mapping.py
+++ b/resdk/resources/kb/mapping.py
@@ -1,0 +1,22 @@
+"""KB mapping resource."""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from ..base import BaseResource
+
+
+class Mapping(BaseResource):
+    """Knowledge base Mapping resource."""
+
+    endpoint = 'kb.mapping.admin'
+    query_endpoint = 'kb.mapping.search'
+    query_method = 'POST'
+
+    WRITABLE_FIELDS = ()
+    UPDATE_PROTECTED_FIELDS = ()
+    READ_ONLY_FIELDS = ('id', 'relation_type', 'source_db', 'source_id', 'target_db', 'target_id')
+
+    def __repr__(self):
+        """Format mapping representation."""
+        # pylint: disable=no-member
+        return "<Mapping source_db='{}' source_id='{}' target_db='{}' target_id='{}'>".format(
+            self.source_db, self.source_id, self.target_db, self.target_id)

--- a/resdk/tests/unit/test_resolwe.py
+++ b/resdk/tests/unit/test_resolwe.py
@@ -92,9 +92,9 @@ class TestResolwe(unittest.TestCase):
         Resolwe.__init__(resolwe_mock, 'a', 'b', 'http://some/url')
         self.assertEqual(resauth_mock.call_count, 1)
         self.assertEqual(resolwe_api_mock.call_count, 1)
-        # There are six instances of ResolweQuery in init: data, process, sample,
-        # presample, collection and feature.
-        self.assertEqual(resolwe_querry_mock.call_count, 6)
+        # There are seven instances of ResolweQuery in init: data, process, sample,
+        # presample, collection, feature and mapping.
+        self.assertEqual(resolwe_querry_mock.call_count, 7)
         self.assertEqual(log_mock.getLogger.call_count, 1)
 
     def test_repr(self):


### PR DESCRIPTION
Requires genialis/resolwe-bio#162 deployed on the backend.

See #69.

Example use:
```python
# Get a list of mappings.
resolwe.mapping.filter(source_db='A', source_id__in=['foo', 'another'])
# Get a list of features.
resolwe.feature.filter(source='UCSC', query=['A1BG'])
```