### PR TITLE
Remove file logger

### DIFF
--- a/resdk/__init__.py
+++ b/resdk/__init__.py
@@ -2,4 +2,4 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from .resolwe import Resolwe, ResolweQuery
-from .resdk_logger import log_to_stdout, log_to_file, start_logging
+from .resdk_logger import log_to_stdout, start_logging

--- a/resdk/resdk_logger.py
+++ b/resdk/resdk_logger.py
@@ -9,7 +9,7 @@ Logging
 Module contents:
 
 #. Parent logger for all modules in resdk library
-#. Handlers STDOUT_HANDLER and FILE_HANDLER ("turned off" by default)
+#. Handler STDOUT_HANDLER is "turned off" by default
 #. Handler configuration functions
 #. Override sys.excepthook to log all uncaught exceptions
 
@@ -20,14 +20,14 @@ Loggers in resdk are named by their module name. This is achieved by::
 
     logger = logging.getLogger(__name__)
 
-This makes it easy to locate the souce of a log message.
+This makes it easy to locate the source of a log message.
 
 Logging handlers
 ================
 
-Two basic handlers STDOUT_HANDLER and FILE_HANDLER are created but not
+The handler STDOUT_HANDLER is created but not
 automatically added to ROOT_LOGGER, which means they do not do anything.
-The handlers are activated when users call logger configuaration
+The handlers are activated when users call logger configuration
 functions like ``start_logging()``.
 
 Handler configuration functions
@@ -44,8 +44,6 @@ the pre-defined handlers she can run::
 .. automethod:: resdk.resdk_logger.start_logging(logging_level=logging.INFO)
 
 .. automethod:: resdk.resdk_logger.log_to_stdout
-
-.. automethod:: resdk.resdk_logger.log_to_file
 
 Log uncaught exceptions
 =======================
@@ -68,7 +66,6 @@ convention for logging in resdk: "Exceptions are explicitly logged
 only when they are caught and not re-raised."
 
 """
-import os
 import sys
 import logging
 
@@ -98,22 +95,10 @@ ROOT_LOGGER.addHandler(logging.NullHandler())
 STDOUT_LOG_LEVEL = logging.INFO
 STDOUT_LOG_ON = True
 
-# Default settings for file handler:
-FILE_LOG_LEVEL = logging.WARNING
-FILE_LOG_ON = False
-FILE_LOG_PATH = os.path.join(os.path.dirname(__file__), 'logfile.txt')
-
 # Create stdout handler and make initial configuration:
 STDOUT_HANDLER = logging.StreamHandler()
 FORMATTER1 = logging.Formatter(fmt='%(message)s')
 STDOUT_HANDLER.setFormatter(FORMATTER1)
-
-# Create file handler and make initial configuration:
-FILE_HANDLER = logging.FileHandler(FILE_LOG_PATH)
-FORMATTER2 = logging.Formatter(
-    fmt='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S')
-FILE_HANDLER.setFormatter(FORMATTER2)
 
 
 def _configure_handler(handler, is_on=None, level=None):
@@ -160,28 +145,6 @@ def log_to_stdout(is_on=None, level=None):
     _configure_handler(STDOUT_HANDLER, is_on=is_on, level=level)
 
 
-def log_to_file(is_on=None, level=None, path=None):
-    """Configure logging to file.
-
-    :param is_on: If True, log to file
-    :type is_on: bool
-    :param level: logging threshold level - integer in [0-50]
-    :type level: int
-    :rtype: None
-
-    """
-    if path is not None:
-        global FILE_HANDLER  # pylint: disable=global-statement
-        old_level = FILE_HANDLER.level
-        # rewrite the FILE_HANDLER instance and configure as before:
-        ROOT_LOGGER.removeHandler(FILE_HANDLER)
-        FILE_HANDLER = logging.FileHandler(path)
-        FILE_HANDLER.setLevel(old_level)
-        FILE_HANDLER.setFormatter(FORMATTER2)
-
-    _configure_handler(FILE_HANDLER, is_on=is_on, level=level)
-
-
 def start_logging(logging_level=logging.INFO):
     """Start logging resdk with the default configuration.
 
@@ -199,7 +162,6 @@ def start_logging(logging_level=logging.INFO):
 
     """
     log_to_stdout(is_on=STDOUT_LOG_ON, level=logging_level or STDOUT_LOG_LEVEL)
-    log_to_file(is_on=FILE_LOG_ON, level=logging_level or FILE_LOG_LEVEL)
 
 
 def _log_all_uncaught_exceptions(exc_type, exc_value, exc_traceback):


### PR DESCRIPTION
The file handler was not used. We should write the logger configuration from scratch in a better way when we will need to log to a file.