### PR TITLE
Remove labels input from cuffnorm

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -4,6 +4,14 @@ Change Log
 
 All notable changes to this project are documented in this file.
 
+==========
+Unreleased
+==========
+
+Changed
+-----
+* Remove labels input from cuffnorm
+
 ==================
 1.8.1 - 2017-04-23
 ==================

--- a/resdk/analysis/expressions.py
+++ b/resdk/analysis/expressions.py
@@ -94,7 +94,6 @@ def cuffnorm(resource, annotation, use_ercc=None, threads=None):
 
     cuffquants = [get_data_id(sample.get_cuffquant()) for sample in samples]
 
-    labels = []
     replicates = []
     replicates_ids = {}
     for sample in samples:
@@ -117,14 +116,10 @@ def cuffnorm(resource, annotation, use_ercc=None, threads=None):
             replicates_ids[relation.id] = str(len(replicates_ids))
         replicates.append(replicates_ids[relation.id])
 
-        if str(relation.id) not in labels:
-            labels.append(str(relation.id))
-
     inputs = {
         'cuffquant': cuffquants,
         'replicates': replicates,
         'annotation': get_data_id(annotation),
-        'labels': labels,
     }
 
     if use_ercc is not None:

--- a/resdk/tests/functional/analysis/e2e_expressions.py
+++ b/resdk/tests/functional/analysis/e2e_expressions.py
@@ -63,7 +63,6 @@ class TestExpressions(BaseResdkFunctionalTest):
         )
         self.assertEqual(cuffnorm.input['annotation'], gff.id)
         self.assertEqual(cuffnorm.input['replicates'], ['0', '0', '1', '1'])
-        self.assertEqual(cuffnorm.input['labels'], [str(group.id), str(group1.id)])
 
         # Run cuffnorm on a two groups of replicates in collection
         cuffnorm = expressions.cuffnorm([group1, group], annotation=gff)
@@ -73,4 +72,3 @@ class TestExpressions(BaseResdkFunctionalTest):
         )
         self.assertEqual(cuffnorm.input['annotation'], gff.id)
         self.assertEqual(cuffnorm.input['replicates'], ['0', '0', '1', '1'])
-        self.assertEqual(cuffnorm.input['labels'], [str(group1.id), str(group.id)])


### PR DESCRIPTION
@dblenkus @jkokosar @JenkoB 

Remove labels from cuffnorm in resdk. This is a follow-up to https://github.com/genialis/resolwe-bio/pull/271.