### PR TITLE
Revert "Work-around for an issue with the latest setuptools (36.0.0)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,6 @@ dist: trusty
 
 language: python
 
-env:
-  global:
-    # XXX: Work-around for the "No module named 'six'" issue with the latest
-    # version of setuptools (36.0.0):
-    # https://github.com/pypa/setuptools/issues/1042
-    - VIRTUALENV_NO_DOWNLOAD=1
-
 # NOTE: Explicit Python versions make Travis job description more informative
 matrix:
   include:


### PR DESCRIPTION
This reverts commit d21ef88bd38eeab5c5cab325b374d5637631687b.
The issue has been fixed in [setuptools 36.0.1](https://setuptools.readthedocs.io/en/latest/history.html#v36-0-1).