### PR TITLE
Allow base dir of upload source files to be specified

### DIFF
--- a/resdk/data_upload/base.py
+++ b/resdk/data_upload/base.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-import os
 
 from resdk.data_upload.samplesheet import FileImporter
 
@@ -11,18 +10,19 @@ __all__ = ('upload_and_annotate',)
 logger = logging.getLogger(__name__)
 
 
-def upload_and_annotate(collection, samplesheet_path, process):
+def upload_and_annotate(collection, samplesheet_path, basedir, process):
     """Upload data files to the Resolwe server, and annotate.
 
-    The data files and sample sheet (.tsv or .xls*) should be in the
-    same directory.
+    The sample sheet (.tsv or .xls*) location is specifed by `samplesheet_path`.
+    The reads files should be located at `basedir`/'filepath', where 'filepath'
+    is specified for each file in the sample sheet.
 
     :param collection: collection to contain the uploaded reads
     :param samplesheet_path: filepath of the sample annotation spreadsheet
+    :param basedir: base directory of the source files
     :param process: data upload function to use (returns failed sample names)
     """
     # Read and validate the annotation template
-    basedir = os.path.dirname(os.path.abspath(samplesheet_path))
     logger.debug(
         "\nChecking the sample annotation spreadsheet at:\n%s",
         samplesheet_path

--- a/resdk/data_upload/multiplexed.py
+++ b/resdk/data_upload/multiplexed.py
@@ -15,11 +15,11 @@ __all__ = ('upload_demulti',)
 logger = logging.getLogger(__name__)
 
 
-def upload_demulti(collection, samplesheet_path):
+def upload_demulti(collection, samplesheet_path, basedir=''):
     """Upload multiplexed reads to the Resolwe server, demultiplex, and annotate.
 
-    The reads files (.qseq) and sample sheet (.tsv or .xls*) should be in the
-    same directory.
+    The reads files (.qseq) should be located at `basedir`/'filepath', where
+    'filepath' is specified for each file in the sample sheet.
 
     Sample-creation and annotation cannot occur until the demultiplexing process
     has finished. Complete sample annotation by rerunning `upload_demulti` on
@@ -28,8 +28,9 @@ def upload_demulti(collection, samplesheet_path):
 
     :param collection: collection to contain the uploaded reads
     :param samplesheet_path: filepath of the sample annotation spreadsheet
+    :param basedir: base directory of the reads and barcodes files
     """
-    upload_and_annotate(collection, samplesheet_path, _upload_multi_samples)
+    upload_and_annotate(collection, samplesheet_path, basedir, _upload_multi_samples)
 
 
 def _upload_multi_samples(sample_dict, basedir, collection, pre_invalid):
@@ -72,7 +73,7 @@ def _demultiplex_samples(sample_list, basedir, collection, pre_invalid):
     """
     try:
         _validate_multiplexed(collection, sample_list, pre_invalid)
-        mapfile = _generate_mapfile(sample_list, os.path.join(basedir, sample_list[0].path))
+        mapfile = _generate_mapfile(sample_list, sample_list[0].path)
         demulti_result = _start_demultiplex(sample_list, mapfile, basedir, collection)
     except ValueError as ex:
         logger.error(ex)

--- a/resdk/data_upload/reads.py
+++ b/resdk/data_upload/reads.py
@@ -12,16 +12,18 @@ __all__ = ('upload_reads',)
 logger = logging.getLogger(__name__)
 
 
-def upload_reads(collection, samplesheet_path):
+def upload_reads(collection, samplesheet_path, basedir=''):
     """Upload NGS reads to the Resolwe server, and annotate.
 
-    The reads files (fastq) and sample sheet (.tsv or .xls*) should be in the
-    same directory.
+    The sample sheet (.tsv or .xls*) location is specifed by `samplesheet_path`.
+    The reads files (.fastq) should be located at `basedir`/'filepath', where
+    'filepath' is specified for each file in the sample sheet.
 
     :param collection: collection to contain the uploaded reads
     :param samplesheet_path: filepath of the sample annotation spreadsheet
+    :param basedir: base directory of the reads files
     """
-    upload_and_annotate(collection, samplesheet_path, _upload_reads_samples)
+    upload_and_annotate(collection, samplesheet_path, basedir, _upload_reads_samples)
 
 
 def _upload_reads_samples(sample_dict, basedir, collection, pre_invalid):

--- a/resdk/tests/functional/data_upload/e2e_upload.py
+++ b/resdk/tests/functional/data_upload/e2e_upload.py
@@ -283,7 +283,7 @@ class TestUpload(BaseResdkFunctionalTest):
         collection = self.res.collection.create(name='Test upload reads')
         samplesheet = self.get_samplesheet()
         with self.assertLogs() as logs:
-            collection.upload_reads(samplesheet)
+            collection.upload_reads(samplesheet, basedir='files')
 
         # Check the error logging
         self.assertEqual(len(logs.output), 37)
@@ -349,7 +349,7 @@ class TestUpload(BaseResdkFunctionalTest):
 
         # Try to duplicate the upload and fail
         with self.assertLogs() as logs2:
-            collection.upload_reads(samplesheet)
+            collection.upload_reads(samplesheet, basedir='files')
         already_up = [
             "Skipping upload of 'single-reads': File already uploaded.",
             "Skipping upload of 'paired-reads': File already uploaded.",
@@ -392,7 +392,7 @@ class TestUpload(BaseResdkFunctionalTest):
         collection = self.res.collection.create(name='Test upload multiplexed')
         samplesheet = self.get_samplesheet()
         with self.assertLogs() as logs:
-            collection.upload_demulti(samplesheet)
+            collection.upload_demulti(samplesheet, basedir='files')
 
         # Check the error logging
         self.assertEqual(len(logs.output), 39)
@@ -458,7 +458,7 @@ class TestUpload(BaseResdkFunctionalTest):
 
         # Try to duplicate the upload and fail
         with self.assertLogs() as logs2:
-            collection.upload_demulti(samplesheet)
+            collection.upload_demulti(samplesheet, basedir='files')
         already_up = (
             upload_errprefix
             + "Skipping upload of 'pool24.read1.small.qseq.bz2': File already uploaded."


### PR DESCRIPTION
@mzganec @mstajdohar Trying out the batch upload functions on Taco, I discovered that we typically don't have write access to the directories where the users put their reads files. So, I had to adjust how the file directories are specified. This PR allows the user to specify the base directory of the reads files, rather than assuming it is the directory containing the annotation spreadsheet. 

I've tested this commit on Taco in a real-world use-case, and the uploads work now. 