### PR TITLE
Update status button link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ Resolwe SDK for Python
     :target: https://travis-ci.org/genialis/resolwe-bio-py
     :alt: Build Status
 
-.. |build-e2e| image:: https://ci.genialis.com/buildStatus/icon?job=genialis-github/resolwe-bio-py/master
-    :target: https://ci.genialis.com/job/genialis-github/job/resolwe-bio-py/job/master/
+.. |build-e2e| image:: https://public.ci.genialis.io/buildStatus/icon/resolwe-bio-py/master
+    :target: https://ci.genialis.io/blue/organizations/jenkins/resolwe-bio-py/activity
     :alt: Build (End-to-End) Status
 
 .. |coverage| image:: https://img.shields.io/codecov/c/github/genialis/resolwe-bio-py/master.svg


### PR DESCRIPTION
- Status icon link domain name updated.
- Status icon in README is updated to work with the two-step authentication on the new Jenkins server.
- When the build status is clicked, link points to the new Blue Ocean interface instead of the old Jenkins interface.
