### PR TITLE
Add duplicate method to collection, sample and data resource

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -5,6 +5,15 @@ Change Log
 All notable changes to this project are documented in this file.
 
 
+==========
+Unreleased
+==========
+
+Added
+-----
+- Add duplicate method to collection, sample and data resources
+
+
 ===================
 11.0.1 - 2019-08-19
 ===================

--- a/resdk/resources/collection.py
+++ b/resdk/resources/collection.py
@@ -185,3 +185,12 @@ class Collection(CollectionRelationsMixin, BaseCollection):
             self._relations = self.resolwe.relation.filter(collection=self.id)
 
         return self._relations
+
+    @assert_object_exists
+    def duplicate(self):
+        """Duplicate (make copy of) ``collection`` object.
+
+        :return: Duplicated collection
+        """
+        duplicated = self.api().duplicate.post({'ids': [self.id]})
+        return self.__class__(resolwe=self.resolwe, **duplicated[0])

--- a/resdk/resources/data.py
+++ b/resdk/resources/data.py
@@ -307,3 +307,12 @@ class Data(BaseResolweResource):
                 output += chunk
 
         return output.decode("utf-8")
+
+    @assert_object_exists
+    def duplicate(self):
+        """Duplicate (make copy of) ``data`` object.
+
+        :return: Duplicated data object
+        """
+        duplicated = self.api().duplicate.post({'ids': [self.id]})
+        return self.__class__(resolwe=self.resolwe, **duplicated[0])

--- a/resdk/resources/sample.py
+++ b/resdk/resources/sample.py
@@ -225,3 +225,18 @@ class Sample(SampleUtilsMixin, BaseCollection):
             self._is_background = len(background_relations) > 0  # pylint: disable=len-as-condition
 
         return self._is_background
+
+    @assert_object_exists
+    def duplicate(self, inherit_collection=False):
+        """Duplicate (make copy of) ``sample`` object.
+
+        :param inherit_collection: If ``True`` then duplicated samples
+            (and their data) will be added to collection of the original
+            sample.
+        :return: Duplicated sample
+        """
+        duplicated = self.api().duplicate.post({
+            'ids': [self.id],
+            'inherit_collection': inherit_collection
+        })
+        return self.__class__(resolwe=self.resolwe, **duplicated[0])

--- a/resdk/tests/functional/duplication/e2e_duplication.py
+++ b/resdk/tests/functional/duplication/e2e_duplication.py
@@ -1,0 +1,31 @@
+# pylint: disable=missing-docstring
+from resdk.exceptions import ResolweServerError
+from resdk.tests.functional.base import USER_USERNAME, BaseResdkFunctionalTest
+
+
+class TestDuplication(BaseResdkFunctionalTest):
+
+    def test_collection_duplication(self):
+        collection = self.res.collection.create(name='Test collection')
+        duplicate = collection.duplicate()
+        self.assertEqual(duplicate.name, 'Copy of Test collection')
+
+        duplicate.delete(force=True)
+        collection.delete(force=True)
+
+    def test_sample_duplication(self):
+        sample = self.res.sample.create(name='Test sample')
+        duplicate = sample.duplicate()
+        self.assertEqual(duplicate.name, 'Copy of Test sample')
+
+        duplicate.delete(force=True)
+        sample.delete(force=True)
+
+    def test_data_duplication(self):
+        data = self.res.run(slug='test-sleep-progress', input={'t': 1})
+        # Let's not wait for processing to finish and
+        # check the expected exception to be raised.
+        with self.assertRaisesRegex(ResolweServerError, 'done or error status to be duplicated'):
+            # Data's `duplicate` raises an exception if status
+            # of the object is not done or error.
+            data.duplicate()


### PR DESCRIPTION
This seems to be working, but it needs some polishing:

- Better output when when a resource is duplicated. Currently the whole duplicated object (dict) is returned
- Tests
- Changelog entry
- SDK Reference?