### PR TITLE
Fix ResdkQuery.get

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -5,9 +5,9 @@ Change Log
 All notable changes to this project are documented in this file.
 
 
-==========
-Unreleased
-==========
+===================
+11.0.1 - 2019-08-19
+===================
 
 Fix
 ---

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -5,6 +5,16 @@ Change Log
 All notable changes to this project are documented in this file.
 
 
+==========
+Unreleased
+==========
+
+Fix
+---
+* Fix ``ResolweQuery.get`` method. This fix handles the case when object is
+  not uniquely defined by ``slug`` (but it is with ``slug`` and ``version``)
+
+
 ===================
 11.0.0 - 2019-08-14
 ===================

--- a/resdk/query.py
+++ b/resdk/query.py
@@ -13,6 +13,8 @@ import copy
 import logging
 import operator
 
+from resdk.resources import DescriptorSchema, Process
+
 
 class ResolweQuery:
     """Query resource endpoints.
@@ -281,6 +283,12 @@ class ResolweQuery:
 
             arg = args[0]
             kwargs = {'id': arg} if str(arg).isdigit() else {self.slug_field: arg}
+
+        if self.slug_field in kwargs:
+            if issubclass(self.resource, (Process, DescriptorSchema)):
+                kwargs['ordering'] = kwargs.get('ordering', '-version')
+
+            kwargs['limit'] = kwargs.get('limit', 1)
 
         new_query = self._clone()
         new_query._add_filter(kwargs)  # pylint: disable=protected-access

--- a/resdk/resolwe.py
+++ b/resdk/resolwe.py
@@ -188,7 +188,7 @@ class Resolwe:
         Raise error if process doesn't exist or more than one is returned.
         """
         # pylint: disable=no-member
-        return self.process.get(slug=slug, ordering='-version', limit=1)
+        return self.process.get(slug=slug)
         # pylint: enable=no-member
 
     def _process_inputs(self, inputs, process):

--- a/resdk/tests/functional/docs/e2e_docs.py
+++ b/resdk/tests/functional/docs/e2e_docs.py
@@ -115,11 +115,11 @@ class BaseResdkDocsFunctionalTest(BaseResdkFunctionalTest):
         return genome_index
 
     def allow_run_process(self, res, slug):
-        process = res.process.filter(slug=slug, ordering='-version')[0]
+        process = res.process.get(slug=slug)
         self.make_public(process, permissions=['view'])
 
     def allow_use_descriptor_schema(self, res, slug):
-        process = res.descriptor_schema.filter(slug=slug, ordering='-version')[0]
+        process = res.descriptor_schema.get(slug=slug)
         self.make_public(process, permissions=['view'])
 
 

--- a/resdk/tests/functional/filters/e2e_filtering.py
+++ b/resdk/tests/functional/filters/e2e_filtering.py
@@ -66,17 +66,9 @@ class TestProcessFilter(BaseResdkFilteringTest):
 
         self.endpoint = self.res.process
 
-        self.star = self.res.process.get(
-            slug='alignment-star',
-            ordering=['-version', 'id'],
-            limit=1,
-        )
+        self.star = self.res.process.get(slug='alignment-star')
 
-        self.hisat2 = self.res.process.get(
-            slug='alignment-hisat2',
-            ordering='-version',
-            limit=1,
-        )
+        self.hisat2 = self.res.process.get(slug='alignment-hisat2')
 
     def test_id(self):
         self._check_filter({'id': self.star.id}, [self.star])


### PR DESCRIPTION
This fixes the case where slug is equal (but version is not) for
multiple objects e.g. for Process or DescriptorSchema.