### PR TITLE
Fix documentation for Resolwe.run

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -13,6 +13,10 @@ Added
 -----
 - Add duplicate method to collection, sample and data resources
 
+Fix
+---
+* Fix documentation for ``Resolwe.run`` ``collection`` parameter
+
 
 ===================
 11.0.1 - 2019-08-19

--- a/resdk/resolwe.py
+++ b/resdk/resolwe.py
@@ -267,7 +267,8 @@ class Resolwe:
         :param dict input: Input values
         :param dict descriptor: Descriptor values
         :param str descriptor_schema: A valid descriptor schema slug
-        :param list collection: Collection into which data object should be included
+        :param int/resource collection: Collection resource or it's id
+            into which data object should be included
         :param str data_name: Default name of data object
 
         :return: data object that was just created


### PR DESCRIPTION
The documentation was not synced how `collection` parameter is treated. Below is a suggested fix.