### PR TITLE
Define ResolweQuery attributes in Resolwe class

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -13,6 +13,8 @@ Changed
 -------
 * **BACKWARD INCOMPATIBLE:** Remove ``Sample.descriptor_completed`` attribute
   and start deprecation procedure for ``Sample.confirm_is_annotated`` method
+* **BACKWARD INCOMPATIBLE:** Remove ``add`` and ``download`` permission to
+  sync with changes in Resolwe
 
 Added
 -----

--- a/resdk/constants.py
+++ b/resdk/constants.py
@@ -11,3 +11,6 @@ ReSDK constants.
 CHUNK_SIZE = 8000000  # 8MB
 
 RESOLWE_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
+
+# Permissions here should be ordered from most to least important
+ALL_PERMISSIONS = ['owner', 'share', 'edit', 'view']

--- a/resdk/resolwe.py
+++ b/resdk/resolwe.py
@@ -80,6 +80,17 @@ class Resolwe:
         'group': 'name',
     }
 
+    data = None
+    collection = None
+    sample = None
+    relation = None
+    process = None
+    descriptor_schema = None
+    user = None
+    group = None
+    feature = None
+    mapping = None
+
     def __init__(self, username=None, password=None, url=None):
         """Initialize attributes."""
         if url is None:

--- a/resdk/resources/base.py
+++ b/resdk/resources/base.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import operator
 
+from ..constants import ALL_PERMISSIONS
 from ..utils.decorators import assert_object_exists
 from .permissions import PermissionsManager
 from .utils import parse_resolwe_datetime
@@ -33,7 +34,7 @@ class BaseResource:
     UPDATE_PROTECTED_FIELDS = ()
     WRITABLE_FIELDS = ()
 
-    ALL_PERMISSIONS = []  # override this in subclass
+    all_permissions = []  # override this in subclass
 
     def __init__(self, resolwe, **model_data):
         """Initialize attributes."""
@@ -202,6 +203,8 @@ class BaseResolweResource(BaseResource):
         'name', 'slug',
     )
 
+    all_permissions = ALL_PERMISSIONS
+
     def __init__(self, resolwe, **model_data):
         """Initialize attributes."""
         self.logger = logging.getLogger(__name__)
@@ -225,7 +228,7 @@ class BaseResolweResource(BaseResource):
         """Permissions."""
         if not self._permissions:
             self._permissions = PermissionsManager(
-                self.ALL_PERMISSIONS,
+                self.all_permissions,
                 self.api(self.id),
                 self.resolwe
             )

--- a/resdk/resources/collection.py
+++ b/resdk/resources/collection.py
@@ -31,8 +31,6 @@ class BaseCollection(BaseResolweResource):
         'description', 'descriptor', 'descriptor_schema', 'settings', 'tags',
     )
 
-    ALL_PERMISSIONS = ['view', 'download', 'add', 'edit', 'share', 'owner']
-
     def __init__(self, resolwe, **model_data):
         """Initialize attributes."""
         self.logger = logging.getLogger(__name__)

--- a/resdk/resources/data.py
+++ b/resdk/resources/data.py
@@ -40,8 +40,6 @@ class Data(BaseResolweResource):
         'collection', 'descriptor', 'descriptor_schema', 'sample', 'tags',
     )
 
-    ALL_PERMISSIONS = ['view', 'download', 'edit', 'share', 'owner']
-
     def __init__(self, resolwe, **model_data):
         """Initialize attributes."""
         self.logger = logging.getLogger(__name__)

--- a/resdk/resources/descriptor.py
+++ b/resdk/resources/descriptor.py
@@ -22,8 +22,6 @@ class DescriptorSchema(BaseResolweResource):
         'description',
     )
 
-    ALL_PERMISSIONS = ['view', 'edit', 'share', 'owner']
-
     def __init__(self, resolwe, **model_data):
         """Initialize attributes."""
         self.logger = logging.getLogger(__name__)

--- a/resdk/resources/permissions.py
+++ b/resdk/resources/permissions.py
@@ -2,6 +2,7 @@
 import copy
 from collections import defaultdict
 
+from ..constants import ALL_PERMISSIONS
 from .utils import is_group, is_user
 
 
@@ -234,7 +235,7 @@ class PermissionsManager:
         perms = copy.copy(perms)
 
         # Order known permissions by importance.
-        for known_perm in ['owner', 'share', 'edit', 'add', 'download', 'view']:
+        for known_perm in ALL_PERMISSIONS:
             if known_perm in perms:
                 perms.remove(known_perm)
                 perms.insert(0, known_perm)

--- a/resdk/resources/process.py
+++ b/resdk/resources/process.py
@@ -24,7 +24,7 @@ class Process(BaseResolweResource):
         'scheduling_class', 'type',
     )
 
-    ALL_PERMISSIONS = ['view', 'share', 'owner']
+    all_permissions = ['view', 'share', 'owner']
 
     def __init__(self, resolwe, **model_data):
         """Initialize attributes."""

--- a/resdk/resources/relation.py
+++ b/resdk/resources/relation.py
@@ -26,8 +26,6 @@ class Relation(BaseResolweResource):
         'collection', 'category', 'partitions', 'unit',
     )
 
-    ALL_PERMISSIONS = ['view', 'edit', 'share', 'owner']
-
     def __init__(self, resolwe, **model_data):
         """Initialize attributes."""
         self.logger = logging.getLogger(__name__)

--- a/resdk/tests/functional/docs/e2e_docs.py
+++ b/resdk/tests/functional/docs/e2e_docs.py
@@ -70,10 +70,8 @@ class BaseResdkDocsFunctionalTest(BaseResdkFunctionalTest):
             slug='upload-fastq-single',
             input={'src': os.path.join(TEST_FILES_DIR, 'reads.fastq.gz')},
         )
-        self.set_slug_and_make_public(reads, self.reads_slug, permissions=['view', 'download'])
-        self.set_slug_and_make_public(
-            reads.sample, self.sample_slug, permissions=['view', 'download']
-        )
+        self.set_slug_and_make_public(reads, self.reads_slug, permissions=['view'])
+        self.set_slug_and_make_public(reads.sample, self.sample_slug, permissions=['view'])
         return reads
 
     def upload_genome(self, res):


### PR DESCRIPTION
This fix removes linter warnings of type: "Resolwe class does not
have a `data` member". The warnings are cuased since these
attributes are not defined in __init__, but in
_initialize_queries.