### PR TITLE
Add cookies to redirects

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -5,6 +5,15 @@ Change Log
 All notable changes to this project are documented in this file.
 
 
+==========
+Unreleased
+==========
+
+Fixed
+-----
+- Add cookies to request on redirect
+
+
 ===================
 12.1.0 - 2020-05-18
 ===================


### PR DESCRIPTION
Adding cookies in custom authenticator does not add cookies to the
automatically generated queries when redirect is followed.

This fix uses session to store auth cookies and only sets headers on custom
authenticator call.