### PR TITLE
Fix broken sample assignment

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -13,6 +13,10 @@ Added
 -----
 - Support login with email
 
+Fixed
+-----
+- Fix broken sample assignment in ``Data`` resource
+
 
 ===================
 12.2.0 - 2020-09-15

--- a/src/resdk/resources/base.py
+++ b/src/resdk/resources/base.py
@@ -132,6 +132,8 @@ class BaseResource:
                     payload[field_name] = self._dehydrate_resources(
                         getattr(self, field_name)
                     )
+            if "sample" in payload:
+                payload["entity"] = payload.pop("sample")
 
             if payload:
                 response = self.api(self.id).patch(payload)
@@ -146,6 +148,9 @@ class BaseResource:
                 for field_name in field_names
                 if getattr(self, field_name) is not None
             }
+
+            if "sample" in payload:
+                payload["entity"] = payload.pop("sample")
 
             response = self.api.post(payload)
             self._update_fields(response)


### PR DESCRIPTION
If updating Data.sample property, one needs to post updates via
entity key, not sample.