### PR TITLE
Add helper class to streamline access to expressions and metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ distribute*.tar.gz
 
 # Ignore testing cache
 .pytest_cache
+
+# Ignore virtualenv folder
+venv/

--- a/docs/ref.rst
+++ b/docs/ref.rst
@@ -8,6 +8,8 @@ SDK Reference
 
 .. automodule:: resdk.resources
 
+.. automodule:: resdk.collection_tables
+
 .. automodule:: resdk.exceptions
 
 .. automodule:: resdk.resdk_logger

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
         'wrapt',
         'pytz>=2018.4',
         'tzlocal>=1.5.1',
+        'pandas>=1.0.0',
     ),
     python_requires='>=3.6',
     extras_require={

--- a/src/resdk/collection_tables.py
+++ b/src/resdk/collection_tables.py
@@ -1,0 +1,268 @@
+""".. Ignore pydocstyle D400.
+
+=================
+Collection Tables
+=================
+
+.. autoclass:: CollectionTables
+    :members:
+
+    .. automethod:: __init__
+"""
+import os
+from datetime import datetime
+from functools import lru_cache
+from io import BytesIO
+from typing import Callable, Dict, List, NamedTuple, Optional
+from urllib.parse import urljoin
+
+import pandas as pd
+import pytz
+
+from resdk import Resolwe
+from resdk.resources import Collection
+from resdk.utils.table_cache import default_cache_dir, load_cache, save_cache
+
+TPM = "tpm"
+COUNTS = "rc"
+EXPRESSION_TYPES = [TPM, COUNTS]
+
+META = "meta"
+
+CHUNK_SIZE = 1000
+
+
+class _TableSample(NamedTuple):
+    sample_slug: str
+    expression_files: Dict[str, str]
+    metadata: dict
+
+
+class CollectionTables:
+    """A helper class to fetch collection's expression and meta data.
+
+    This class enables fetching given collection's data and returning it as tables which have samples in rows
+    and gene symbols in columns.
+
+    When calling :meth:`CollectionTables.expressions`, :meth:`CollectionTables.counts` and
+    :meth:`CollectionTables.metadata` for the first time the corresponding data gets fetched from the server.
+    This data than gets cached in memory and on disc and is used in consequent calls until the modified
+    attribute changes.
+    """
+
+    def __init__(self, collection: Collection, cache_dir=None):
+        """Initialize class.
+
+        :param collection: collection to use
+        :param cache_dir: cache directory location, if not specified system specific cache directory is used
+        """
+        self.resolwe = collection.resolwe  # type: Resolwe
+        self.collection = collection
+        if self.collection.samples.count() == 0:
+            raise ValueError(f"Collection {self.collection.name} has no samples!")
+
+        self.cache_dir = cache_dir
+        if self.cache_dir is None:
+            self.cache_dir = default_cache_dir()
+        if not os.path.exists(self.cache_dir):
+            os.makedirs(self.cache_dir)
+
+        self._table_samples_ = []  # type: List[_TableSample]
+        self._meta = None  # type: Optional[pd.DataFrame]
+        self._expressions = {}  # type: Dict[str, pd.DataFrame]
+        self._gene_map_ = {}  # type: Dict[str, str]
+        self._modified = None  # type: Optional[datetime]
+
+    @property
+    def modified(self) -> datetime:
+        """Return the newest modification date out of all sample.
+
+        The returned datetime object is used to detect data changes on the server.
+
+        :return: modified datetime in UTC
+        """
+        if self._modified is None:
+            newest_modified = max(s.modified for s in self.collection.samples.iterate())
+            # transform into UTC so changing timezones won't effect cache
+            self._modified = newest_modified.astimezone(pytz.utc)
+        return self._modified
+
+    @lru_cache()
+    def metadata(self) -> pd.DataFrame:
+        """Return samples metadata in a table format.
+
+        :return: table of metadata
+        """
+        cache = load_cache(self.cache_dir, self.collection.slug, META, self.modified)
+        if cache is not None:
+            self._meta = cache
+
+        if self._meta is None:
+            self._meta = self._get_metadata()
+
+        save_cache(
+            self._meta, self.cache_dir, self.collection.slug, META, self.modified
+        )
+        return self._meta
+
+    def _get_metadata(self) -> pd.DataFrame:
+        """Flatten samples JSON metadata into a table."""
+        meta = pd.json_normalize([ts.metadata for ts in self._table_samples])
+        meta = meta.set_index("sample_slug").sort_index()
+        return meta
+
+    @property
+    def _table_samples(self) -> List[_TableSample]:
+        """Return a list of _TableSample objects containing expression files urls and metadata."""
+        if not self._table_samples_:
+            self._table_samples_ = self._get_table_samples()
+        return self._table_samples_
+
+    def _get_table_samples(self):
+        """Fetch expressions files urls and sample metadata."""
+        table_samples = []
+        for sample in self.collection.samples.iterate():
+            # get sample metadata from description
+            metadata = sample.descriptor
+            metadata["sample_slug"] = sample.slug
+
+            # get expressions data objects
+            try:
+                expression = sample.get_expression()
+            except LookupError:
+                raise LookupError(
+                    f"Sample {sample.slug} has not expression data!"
+                ) from None
+
+            # get expression files urls
+            expression_files = {}
+            for exp_type in EXPRESSION_TYPES:
+                exp_files = expression.files(field_name=exp_type)
+                assert (
+                    len(exp_files) == 1
+                ), "Multiple expression files with same expression type!"
+                exp_file = exp_files[0]
+                exp_file_url = "{}/{}".format(expression.id, exp_file)
+                expression_files[exp_type] = exp_file_url
+
+            table_samples.append(
+                _TableSample(
+                    sample_slug=sample.slug,
+                    expression_files=expression_files,
+                    metadata=metadata,
+                )
+            )
+        return table_samples
+
+    @lru_cache(maxsize=16)
+    def expressions(
+        self, preprocess: Optional[Callable[[pd.DataFrame], pd.DataFrame]] = None
+    ) -> pd.DataFrame:
+        """Return TPM data in a table format.
+
+        If a data preprocess is set then its executed and its results returned and cached in memory. The preprocess
+        must be a callable that expects one argument of type DataFrame and return an object of the same type.
+
+        :param preprocess: a callable that preprocess expression data
+        :return: table of TPM
+        """
+        cache = load_cache(self.cache_dir, self.collection.slug, TPM, self.modified)
+        if cache is not None:
+            self._expressions[TPM] = cache
+
+        if TPM not in self._expressions:
+            self._expressions[TPM] = self._download_expressions(TPM)
+
+        save_cache(
+            self._expressions[TPM],
+            self.cache_dir,
+            self.collection.slug,
+            TPM,
+            self.modified,
+        )
+
+        _expressions = self._expressions[TPM]
+        if preprocess is not None:
+            _expressions = preprocess(_expressions.copy())
+        return _expressions
+
+    @lru_cache()
+    def counts(self) -> pd.DataFrame:
+        """Return counts in a table format.
+
+        :return: table of counts
+        """
+        cache = load_cache(self.cache_dir, self.collection.slug, COUNTS, self.modified)
+        if cache is not None:
+            self._expressions[COUNTS] = cache
+
+        if COUNTS not in self._expressions:
+            self._expressions[COUNTS] = self._download_expressions(COUNTS)
+
+        save_cache(
+            self._expressions[COUNTS],
+            self.cache_dir,
+            self.collection.slug,
+            COUNTS,
+            self.modified,
+        )
+        return self._expressions[COUNTS]
+
+    def _gene_map(self, ensembl_ids: List[str]) -> dict:
+        """Return the mapping of ensemble ids to gene symbols.
+
+        :param ensembl_ids: list of ensemble ids
+        :return: dictionary with ensemble ids as keys and gene symbol for corresponding values
+        """
+        if not self._gene_map_:
+            self._gene_map_ = self._get_gene_map(ensembl_ids)
+        return self._gene_map_
+
+    def _get_gene_map(self, ensembl_ids: List[str]) -> dict:
+        """Fetch gene mapping from resolwe server."""
+        sublists = [
+            ensembl_ids[i : i + CHUNK_SIZE]
+            for i in range(0, len(ensembl_ids), CHUNK_SIZE)
+        ]
+        species = self._table_samples[0].metadata["general"]["species"]
+        gene_map = {}
+        for sublist in sublists:
+            features = self.resolwe.feature.filter(
+                species=species, feature_id__in=sublist
+            )
+            gene_map.update({f.feature_id: f.name for f in features})
+        return gene_map
+
+    def _gene_mapping(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Transform columns of the given table from ensemble ids to gene symbols."""
+        genes = df.columns.tolist()
+        gene_map = self._gene_map(genes)
+        df.columns = df.columns.map(gene_map)
+        return df
+
+    def _download_expressions(self, exp_type: str) -> pd.DataFrame:
+        """Download expression files and marge them into a pandas DataFrame.
+
+        :param exp_type: expression type
+        :return: table with expression data, genes in columns, samples in rows
+        """
+        df_list = []
+        for ts in self._table_samples:
+            full_file_url = urljoin(
+                self.resolwe.url, f"data/{ts.expression_files[exp_type]}"
+            )
+            response = self.resolwe.session.get(full_file_url, auth=self.resolwe.auth)
+            response.raise_for_status()
+            with BytesIO() as f:
+                f.write(response.content)
+                f.seek(0)
+                df_ = pd.read_csv(f, sep="\t", compression="gzip")
+                df_ = df_.set_index("Gene").T
+                df_.index = [ts.sample_slug]
+                df_list.append(df_)
+
+        df = pd.concat(df_list, axis=0).sort_index()
+        df.index.name = "sample_slug"
+        df.columns.name = None
+        df = self._gene_mapping(df)
+        return df

--- a/src/resdk/utils/table_cache.py
+++ b/src/resdk/utils/table_cache.py
@@ -1,0 +1,60 @@
+"""Cache util functions for CollectionTables."""
+import os
+import sys
+from datetime import datetime
+from typing import Optional
+
+import pandas as pd
+
+from resdk.__about__ import __version__
+
+
+def default_cache_dir() -> str:
+    """Return default cache directory specific for the current OS. Code from Orange3.misc.environ."""
+    if sys.platform == "darwin":
+        base = os.path.expanduser("~/Library/Caches")
+    elif sys.platform == "win32":
+        base = os.getenv("APPDATA", os.path.expanduser("~/AppData/Local"))
+    elif os.name == "posix":
+        base = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
+    else:
+        base = os.path.expanduser("~/.cache")
+
+    base = os.path.join(base, "ReSDK", __version__)
+    if sys.platform == "win32":
+        # On Windows cache and data dir are the same.
+        # Microsoft suggest using a Cache subdirectory
+        return os.path.join(base, "Cache")
+    else:
+        return base
+
+
+def load_cache(
+    directory: str, collection_slug: str, data_type: str, modified: datetime
+) -> Optional[pd.DataFrame]:
+    """If there is a cached file for the same data return it."""
+    full_cache_file = _full_cache_file(directory, collection_slug, data_type, modified)
+    if os.path.exists(full_cache_file):
+        return pd.read_pickle(full_cache_file)
+
+
+def save_cache(
+    df: pd.DataFrame,
+    directory: str,
+    collection_slug: str,
+    data_type: str,
+    modified: datetime,
+):
+    """If not existing, save data to cache file."""
+    full_cache_file = _full_cache_file(directory, collection_slug, data_type, modified)
+    if not os.path.exists(full_cache_file):
+        df.to_pickle(full_cache_file)
+
+
+def _full_cache_file(
+    directory: str, collection_slug: str, data_type: str, modified: datetime
+) -> str:
+    """Return full path to specified cache file."""
+    datetime_str = modified.isoformat()
+    cache_file = f"{collection_slug}_{data_type}_{datetime_str}.pickle"
+    return os.path.join(directory, cache_file)

--- a/tests/unit/test_collection_tables.py
+++ b/tests/unit/test_collection_tables.py
@@ -1,0 +1,358 @@
+import unittest
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytz
+from mock import ANY, MagicMock, PropertyMock, call, patch
+from pandas.testing import assert_frame_equal
+
+from resdk.collection_tables import COUNTS, META, TPM, CollectionTables, _TableSample
+from resdk.resolwe import Resolwe
+from resdk.resources import Collection, Data, Sample
+from resdk.resources.kb import Feature
+
+
+class TestCollectionTables(unittest.TestCase):
+    def setUp(self):
+        self.sample = MagicMock(spec=Sample)
+        self.collection = MagicMock(spec=Collection)
+        self.collection.slug = "slug"
+        self.collection.name = "Name"
+        self.collection.samples.count.return_value = 1
+        self.collection.samples.iterate.return_value = [self.sample]
+        self.resolwe = MagicMock(spec=Resolwe)
+        self.collection.resolwe = self.resolwe
+        self.table_samples = [
+            MagicMock(
+                spec=_TableSample,
+                sample_slug=str(i),
+                expression_files={TPM: f"{i}/tpm.csv", COUNTS: f"{i}/counts.csv"},
+                metadata={"sample_slug": str(i), "PFS": i ** 2},
+            )
+            for i in range(3)
+        ]
+        self.metadata_df = pd.DataFrame(
+            [[0], [1], [4]], index=["0", "1", "2"], columns=["PFS"]
+        )
+        self.metadata_df.index.name = "sample_slug"
+        self.expressions_df = pd.DataFrame(
+            [[0, 1, 2], [1, 2, 3], [2, 3, 4]],
+            index=["0", "1", "2"],
+            columns=["GA", "GB", "GC"],
+        )
+        self.expressions_df.index.name = "sample_slug"
+        self.ensembl_ids = ["ENSG001", "ENSG002", "ENSG003"]
+        self.gene_map = {"ENSG001": "GA", "ENSG002": "GB", "ENSG003": "GC"}
+
+    @patch("resdk.collection_tables.default_cache_dir")
+    @patch("os.path.exists")
+    def test_init(self, exists_mock, cache_mock):
+        cache_mock.return_value = "/tmp/resdk/"
+        ct = CollectionTables(self.collection)
+
+        self.assertIs(ct.collection, self.collection)
+        self.assertEqual(ct.cache_dir, "/tmp/resdk/")
+        exists_mock.assert_called_with("/tmp/resdk/")
+
+        # using different cache dir
+        ct = CollectionTables(self.collection, cache_dir="/tmp/cache_dir/")
+        self.assertEqual(ct.cache_dir, "/tmp/cache_dir/")
+        exists_mock.assert_called_with("/tmp/cache_dir/")
+
+        # using collection with no samples should rise error
+        self.collection.samples.count.return_value = 0
+        with self.assertRaises(ValueError):
+            CollectionTables(self.collection)
+
+    def test_modified(self):
+        sample_datetime = datetime(2020, 11, 1, 12, 15, 0, 0, tzinfo=pytz.UTC)
+        self.sample.modified = sample_datetime
+
+        ct = CollectionTables(self.collection)
+        self.assertEqual(ct.modified, sample_datetime)
+
+        # check if the newest
+        self.collection.samples.iterate.return_value = [
+            MagicMock(spec=Sample, modified=sample_datetime + timedelta(minutes=5 * i))
+            for i in range(3)
+        ]
+        ct = CollectionTables(self.collection)
+        self.assertEqual(
+            ct.modified, datetime(2020, 11, 1, 12, 25, 0, 0, tzinfo=pytz.UTC)
+        )
+
+        # datetime should transform into UTC
+        self.collection.samples.iterate.return_value = [
+            MagicMock(
+                spec=Sample,
+                modified=sample_datetime.astimezone(pytz.timezone("Europe/Ljubljana")),
+            )
+        ]
+        ct = CollectionTables(self.collection)
+        self.assertEqual(ct.modified, sample_datetime)
+
+        # modified should be calculated only once
+        self.collection.samples.iterate.reset_mock()
+        ct = CollectionTables(self.collection)
+        _ = ct.modified
+        self.collection.samples.iterate.assert_called_once()
+        _ = ct.modified
+        self.collection.samples.iterate.assert_called_once()
+
+    @patch("resdk.collection_tables.load_cache")
+    @patch("resdk.collection_tables.save_cache")
+    @patch.object(CollectionTables, "_get_metadata")
+    def test_metadata(self, get_mock, save_mock, load_mock):
+        get_mock.return_value = self.metadata_df
+        load_mock.return_value = None
+
+        ct = CollectionTables(self.collection)
+        return_meta = ct.metadata()
+
+        load_mock.assert_called_once()
+        load_mock.assert_called_once_with(ANY, ANY, META, ANY)
+        get_mock.assert_called_once()
+        save_mock.assert_called_once()
+        save_mock.assert_called_once_with(self.metadata_df, ANY, ANY, META, ANY)
+        self.assertIs(return_meta, self.metadata_df)
+
+        # test cache behavior
+        load_mock.reset_mock()
+        load_mock.return_value = self.metadata_df
+        get_mock.reset_mock()
+
+        ct = CollectionTables(self.collection)
+        return_meta = ct.metadata()
+        # if on disk don't fetch from web
+        load_mock.assert_called_once()
+        get_mock.assert_not_called()
+        self.assertIs(return_meta, self.metadata_df)
+
+        load_mock.reset_mock()
+        return_meta = ct.metadata()
+        # if in memory don't load from disk
+        load_mock.assert_not_called()
+        get_mock.assert_not_called()
+        self.assertIs(return_meta, self.metadata_df)
+
+    @patch.object(CollectionTables, "_table_samples", new_callable=PropertyMock)
+    def test_get_metadata(self, samples_mock):
+        samples_mock.return_value = self.table_samples
+        ct = CollectionTables(self.collection)
+        metadata = ct._get_metadata()
+        assert_frame_equal(metadata, self.metadata_df)
+
+    @patch.object(CollectionTables, "_get_table_samples")
+    def test_table_samples(self, get_mock):
+        get_mock.return_value = self.table_samples
+
+        ct = CollectionTables(self.collection)
+        return_samples = ct._table_samples
+        get_mock.assert_called_once()
+        self.assertListEqual(return_samples, self.table_samples)
+
+        # fetch table samples only once
+        return_samples = ct._table_samples
+        get_mock.assert_called_once()
+        self.assertListEqual(return_samples, self.table_samples)
+
+    def test_get_table_samples(self):
+        def files(field_name=None):
+            if field_name == TPM:
+                return ["tpm.csv"]
+            elif field_name == COUNTS:
+                return ["counts.csv"]
+            else:
+                raise Exception
+
+        files_mock = MagicMock(side_effect=files)
+        expression_mock = MagicMock(spec=Data, id=123, files=files_mock)
+        self.sample.get_expression.return_value = expression_mock
+        self.sample.descriptor = {"PFS": 42}
+        self.sample.slug = "sample_42"
+
+        ct = CollectionTables(self.collection)
+        table_samples = ct._get_table_samples()
+        self.assertEqual(len(table_samples), 1)
+        self.assertIsInstance(table_samples[0], _TableSample)
+        self.assertEqual(
+            table_samples[0].metadata, {"sample_slug": "sample_42", "PFS": 42}
+        )
+        self.assertEqual(table_samples[0].sample_slug, "sample_42")
+        self.assertEqual(table_samples[0].expression_files[TPM], "123/tpm.csv")
+        self.assertEqual(table_samples[0].expression_files[COUNTS], "123/counts.csv")
+
+        # raise exception on sample with no expression data
+        self.sample.get_expression = MagicMock(side_effect=LookupError)
+        ct = CollectionTables(self.collection)
+        with self.assertRaisesRegex(LookupError, "Sample sample_42 *"):
+            ct._get_table_samples()
+
+        # check for multiple expression files
+        self.sample.get_expression = MagicMock(spec=Data)
+        self.sample.get_expression.return_value.files.return_value = [1, 2, 3]
+        ct = CollectionTables(self.collection)
+        with self.assertRaisesRegex(AssertionError, "Multiple expression files *"):
+            ct._get_table_samples()
+
+    @patch("resdk.collection_tables.load_cache")
+    @patch("resdk.collection_tables.save_cache")
+    @patch.object(CollectionTables, "_download_expressions")
+    def test_expressions(self, download_mock, save_mock, load_mock):
+        download_mock.return_value = self.expressions_df
+        load_mock.return_value = None
+
+        ct = CollectionTables(self.collection)
+        return_expression = ct.expressions()
+
+        load_mock.assert_called_once()
+        load_mock.assert_called_once_with(ANY, ANY, TPM, ANY)
+        download_mock.assert_called_once()
+        save_mock.assert_called_once()
+        save_mock.assert_called_once_with(self.expressions_df, ANY, ANY, TPM, ANY)
+        self.assertIs(return_expression, self.expressions_df)
+
+        # if on disk don't fetch from web
+        load_mock.reset_mock()
+        load_mock.return_value = self.expressions_df
+        download_mock.reset_mock()
+
+        ct = CollectionTables(self.collection)
+        return_expression = ct.expressions()
+
+        load_mock.assert_called_once()
+        download_mock.assert_not_called()
+        self.assertIs(return_expression, self.expressions_df)
+
+        # use preprocessor
+        preprocessor_mock = MagicMock(side_effect=lambda x: x + 1)
+        ct = CollectionTables(self.collection)
+        return_expression = ct.expressions(preprocess=preprocessor_mock)
+        preprocessor_mock.assert_called_once()
+        assert_frame_equal(return_expression, preprocessor_mock(self.expressions_df))
+
+        # cache in memory
+        load_mock.reset_mock()
+        preprocessor_mock.reset_mock()
+        return_cache_expression = ct.expressions(preprocess=preprocessor_mock)
+        load_mock.assert_not_called()
+        preprocessor_mock.assert_not_called()
+        download_mock.assert_not_called()
+        self.assertIs(return_cache_expression, return_expression)
+
+    @patch("resdk.collection_tables.load_cache")
+    @patch("resdk.collection_tables.save_cache")
+    @patch.object(CollectionTables, "_download_expressions")
+    def test_counts(self, download_mock, save_mock, load_mock):
+        download_mock.return_value = self.expressions_df
+        load_mock.return_value = None
+
+        ct = CollectionTables(self.collection)
+        return_counts = ct.counts()
+
+        load_mock.assert_called_once()
+        load_mock.assert_called_once_with(ANY, ANY, COUNTS, ANY)
+        download_mock.assert_called_once()
+        save_mock.assert_called_once()
+        save_mock.assert_called_once_with(self.expressions_df, ANY, ANY, COUNTS, ANY)
+        self.assertIs(return_counts, self.expressions_df)
+
+        # test cache behavior
+        load_mock.reset_mock()
+        load_mock.return_value = self.metadata_df
+        download_mock.reset_mock()
+
+        ct = CollectionTables(self.collection)
+        return_counts = ct.counts()
+        # if on disk don't fetch from web
+        load_mock.assert_called_once()
+        download_mock.assert_not_called()
+        self.assertIs(return_counts, self.metadata_df)
+
+        load_mock.reset_mock()
+        return_counts = ct.counts()
+        # if in memory don't load from disk
+        load_mock.assert_not_called()
+        download_mock.assert_not_called()
+        self.assertIs(return_counts, self.metadata_df)
+
+    @patch.object(CollectionTables, "_get_gene_map")
+    def test_gene_map(self, get_mock):
+        get_mock.return_value = self.gene_map
+
+        ct = CollectionTables(self.collection)
+        return_map = ct._gene_map(self.ensembl_ids)
+        get_mock.assert_called_once()
+        get_mock.assert_called_once_with(self.ensembl_ids)
+        self.assertDictEqual(return_map, self.gene_map)
+
+        # fetch gene map only once
+        return_map = ct._gene_map(self.ensembl_ids)
+        get_mock.assert_called_once()
+        self.assertDictEqual(return_map, self.gene_map)
+
+    @patch.object(CollectionTables, "_table_samples")
+    def test_get_gene_map(self, sample_mock):
+        def create_feature(fid, name):
+            m = MagicMock(spec=Feature, feature_id=fid)
+            # name can't be set on initialization
+            m.name = name
+            return m
+
+        sample_mock.__getitem__().metadata = {"general": {"species": "Homo sapiens"}}
+        self.resolwe.feature.filter.return_value = [
+            create_feature(fid, name) for fid, name in self.gene_map.items()
+        ]
+
+        ct = CollectionTables(self.collection)
+        return_map = ct._get_gene_map(self.ensembl_ids)
+
+        self.resolwe.feature.filter.assert_called_once()
+        self.resolwe.feature.filter.assert_called_once_with(
+            species="Homo sapiens", feature_id__in=self.ensembl_ids
+        )
+        self.assertDictEqual(return_map, self.gene_map)
+
+    @patch.object(CollectionTables, "_gene_map")
+    def test_gene_mapping(self, map_mock):
+        map_mock.return_value = self.gene_map
+        pre_map_df = self.expressions_df.copy()
+        pre_map_df.columns = self.ensembl_ids
+
+        ct = CollectionTables(self.collection)
+        mapped_df = ct._gene_mapping(pre_map_df)
+        assert_frame_equal(mapped_df, self.expressions_df)
+
+    @patch("resdk.collection_tables.BytesIO", MagicMock)
+    @patch(
+        "pandas.read_csv",
+        MagicMock(
+            side_effect=[
+                pd.DataFrame(
+                    [["GA", 0 + i], ["GB", 1 + i], ["GC", 2 + i]],
+                    columns=["Gene", "Expression"],
+                )
+                for i in range(3)
+            ]
+        ),
+    )
+    @patch.object(CollectionTables, "_table_samples", new_callable=PropertyMock)
+    @patch.object(CollectionTables, "_gene_mapping", new_callable=PropertyMock)
+    def test_download_expressions(self, map_mock, sample_mock):
+        map_mock.return_value = lambda x: x
+        sample_mock.return_value = self.table_samples
+        self.resolwe.url = "https://server.com"
+        self.resolwe.auth = MagicMock()
+        get_mock = MagicMock(return_value=MagicMock())
+        self.resolwe.session.get = get_mock
+
+        ct = CollectionTables(self.collection)
+        expression_df = ct._download_expressions(TPM)
+
+        get_calls = [
+            call("https://server.com/data/0/tpm.csv", auth=ANY),
+            call("https://server.com/data/1/tpm.csv", auth=ANY),
+            call("https://server.com/data/2/tpm.csv", auth=ANY),
+        ]
+        get_mock.assert_has_calls(get_calls)
+        assert_frame_equal(expression_df, self.expressions_df)

--- a/tests/unit/test_tables_cache.py
+++ b/tests/unit/test_tables_cache.py
@@ -1,0 +1,97 @@
+import unittest
+from datetime import datetime
+
+import pandas as pd
+import pytz
+from mock import MagicMock, patch
+
+from resdk.utils.table_cache import (
+    _full_cache_file,
+    default_cache_dir,
+    load_cache,
+    save_cache,
+)
+
+
+class TestCache(unittest.TestCase):
+    @patch("resdk.utils.table_cache.__version__", "0.0.0")
+    def test_default_cache_dir(self):
+        with patch("sys.platform", "darwin"):
+            self.assertTrue(default_cache_dir().endswith("Library/Caches/ReSDK/0.0.0"))
+
+        with patch("sys.platform", "win32"):
+            self.assertTrue(
+                default_cache_dir().endswith("AppData/Local/ReSDK/0.0.0/Cache")
+            )
+
+        with patch("sys.platform", "posix"):
+            self.assertTrue(default_cache_dir().endswith(".cache/ReSDK/0.0.0"))
+
+    def test_full_cache_file(self):
+        dt = datetime(2020, 11, 1, 12, 15, 30, 123456, pytz.UTC)
+        path = _full_cache_file("/tmp/", "coll_slug", "dtype", dt)
+        self.assertEqual(
+            path, "/tmp/coll_slug_dtype_2020-11-01T12:15:30.123456+00:00.pickle"
+        )
+
+    @patch("os.path.exists")
+    @patch("pandas.read_pickle")
+    def test_load_cache(self, read_mock, path_mock):
+        # load existing cache file
+        path_mock.return_value = True
+        table_mock = MagicMock(spec=pd.DataFrame)
+        read_mock.return_value = table_mock
+        table = load_cache(
+            "/tmp/", "coll_slug", "dtype", datetime(2020, 11, 1, 12, 0, 0, 0, pytz.UTC)
+        )
+
+        path_mock.assert_called_with(
+            "/tmp/coll_slug_dtype_2020-11-01T12:00:00+00:00.pickle"
+        )
+        read_mock.assert_called_with(
+            "/tmp/coll_slug_dtype_2020-11-01T12:00:00+00:00.pickle"
+        )
+        self.assertIs(table, table_mock)
+
+        # return None for non-existing cache
+        read_mock.reset_mock()
+        path_mock.return_value = False
+        table = load_cache(
+            "/tmp/", "coll_slug", "dtype", datetime(2020, 11, 1, 12, 0, 0, 0, pytz.UTC)
+        )
+        read_mock.assert_not_called()
+        self.assertIsNone(table)
+
+    @patch("os.path.exists")
+    def test_save_cache(self, path_mock):
+        # save to cache file if not non-existing
+        path_mock.return_value = False
+        table_mock = MagicMock(spec=pd.DataFrame)
+        to_mock = table_mock.to_pickle
+        save_cache(
+            table_mock,
+            "/tmp/",
+            "coll_slug",
+            "dtype",
+            datetime(2020, 11, 1, 12, 0, 0, 0, pytz.UTC),
+        )
+
+        path_mock.assert_called_with(
+            "/tmp/coll_slug_dtype_2020-11-01T12:00:00+00:00.pickle"
+        )
+        to_mock.assert_called_with(
+            "/tmp/coll_slug_dtype_2020-11-01T12:00:00+00:00.pickle"
+        )
+
+        # don't save if cache file exists
+        to_mock.reset_mock()
+        path_mock.return_value = True
+        save_cache(
+            table_mock,
+            "/tmp/",
+            "coll_slug",
+            "dtype",
+            datetime(2020, 11, 1, 12, 0, 0, 0, pytz.UTC),
+        )
+
+        to_mock.assert_not_called()


### PR DESCRIPTION
This partially implements [spec](https://docs.google.com/document/d/1et1jxY9TAKabcOxb8EO4qRfUQwc8sg_wUKzcZI_ZzCc/edit#).

What is implemented:
 * extend ReSDK API similar to "Alternative 3" with some exceptions: 
   - selection of the used collection is moved to class initialization as holding multiple collections in a single object seems a bit messy
   - instead of the name `ResolweBio` I used `CollectionTables` as this class functionality is, in a nutshell, exporting collections as tables of data
* fetching expressions, counts, metadata from ReSDK server
* caching data in memory and on disc as long as modified on samples doesn't change
* returned tables have samples in rows and gene symbols for columns