### PR TITLE
Update API and add performance enhancements to CollectionTables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setuptools.setup(
         'pytz>=2018.4',
         'tzlocal>=1.5.1',
         'pandas>=1.0.0',
+        'tqdm',
     ),
     python_requires='>=3.6',
     extras_require={

--- a/src/resdk/__init__.py
+++ b/src/resdk/__init__.py
@@ -1,3 +1,4 @@
 """Resolwe SDK for Python."""
+from .collection_tables import CollectionTables  # noqa
 from .resdk_logger import log_to_stdout, start_logging  # noqa
 from .resolwe import Resolwe, ResolweQuery  # noqa

--- a/src/resdk/utils/table_cache.py
+++ b/src/resdk/utils/table_cache.py
@@ -1,16 +1,18 @@
 """Cache util functions for CollectionTables."""
 import os
+import pickle
 import sys
-from datetime import datetime
-from typing import Optional
-
-import pandas as pd
+from shutil import rmtree
+from typing import Any
 
 from resdk.__about__ import __version__
 
 
-def default_cache_dir() -> str:
-    """Return default cache directory specific for the current OS. Code from Orange3.misc.environ."""
+def _default_cache_dir() -> str:
+    """Return default cache directory specific for the current OS.
+
+    Code originally from Orange3.misc.environ.
+    """
     if sys.platform == "darwin":
         base = os.path.expanduser("~/Library/Caches")
     elif sys.platform == "win32":
@@ -19,8 +21,22 @@ def default_cache_dir() -> str:
         base = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
     else:
         base = os.path.expanduser("~/.cache")
+    return base
 
-    base = os.path.join(base, "ReSDK", __version__)
+
+def cache_dir_resdk_base() -> str:
+    """Return base ReSDK cache directory."""
+    return os.path.join(_default_cache_dir(), "ReSDK")
+
+
+def cache_dir_resdk() -> str:
+    """Return ReSDK cache directory."""
+    v = __version__
+    if "dev" in v:
+        # remove git commit hash
+        v = v[: v.find("dev") + 3]
+    base = os.path.join(cache_dir_resdk_base(), v)
+
     if sys.platform == "win32":
         # On Windows cache and data dir are the same.
         # Microsoft suggest using a Cache subdirectory
@@ -29,32 +45,30 @@ def default_cache_dir() -> str:
         return base
 
 
-def load_cache(
-    directory: str, collection_slug: str, data_type: str, modified: datetime
-) -> Optional[pd.DataFrame]:
-    """If there is a cached file for the same data return it."""
-    full_cache_file = _full_cache_file(directory, collection_slug, data_type, modified)
-    if os.path.exists(full_cache_file):
-        return pd.read_pickle(full_cache_file)
+def clear_cache_dir_resdk() -> None:
+    """Delete all cache files from the default cache directory."""
+    cache_dir = cache_dir_resdk_base()
+    if os.path.exists(cache_dir):
+        rmtree(cache_dir)
 
 
-def save_cache(
-    df: pd.DataFrame,
-    directory: str,
-    collection_slug: str,
-    data_type: str,
-    modified: datetime,
-):
-    """If not existing, save data to cache file."""
-    full_cache_file = _full_cache_file(directory, collection_slug, data_type, modified)
-    if not os.path.exists(full_cache_file):
-        df.to_pickle(full_cache_file)
+def load_pickle(pickle_file: str) -> Any:
+    """Load object from the pickle file.
+
+    :param pickle_file: file path
+    :return: un-pickled object
+    """
+    if os.path.exists(pickle_file):
+        return pickle.load(open(pickle_file, "rb"))
 
 
-def _full_cache_file(
-    directory: str, collection_slug: str, data_type: str, modified: datetime
-) -> str:
-    """Return full path to specified cache file."""
-    datetime_str = modified.isoformat()
-    cache_file = f"{collection_slug}_{data_type}_{datetime_str}.pickle"
-    return os.path.join(directory, cache_file)
+def save_pickle(obj: Any, pickle_file: str, override=False) -> None:
+    """Save given object into a pickle file.
+
+    :param obj: object to bi pickled
+    :param pickle_file: file path
+    :param override: if True than override existing file
+    :return:
+    """
+    if not os.path.exists(pickle_file) or override:
+        pickle.dump(obj, open(pickle_file, "wb"))

--- a/tests/unit/test_collection_tables.py
+++ b/tests/unit/test_collection_tables.py
@@ -1,53 +1,62 @@
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime
+from time import sleep, time
 
 import pandas as pd
 import pytz
-from mock import ANY, MagicMock, PropertyMock, call, patch
+from mock import MagicMock, patch
 from pandas.testing import assert_frame_equal
 
-from resdk.collection_tables import COUNTS, META, TPM, CollectionTables, _TableSample
-from resdk.resolwe import Resolwe
-from resdk.resources import Collection, Data, Sample
-from resdk.resources.kb import Feature
+from resdk import CollectionTables
+from resdk.collection_tables import EXP, META, RC
 
 
 class TestCollectionTables(unittest.TestCase):
     def setUp(self):
-        self.sample = MagicMock(spec=Sample)
-        self.collection = MagicMock(spec=Collection)
+        self.sample = MagicMock()
+        self.sample.modified = datetime(
+            2020, 11, 1, 12, 15, 0, 0, tzinfo=pytz.UTC
+        ).astimezone(pytz.timezone("Europe/Ljubljana"))
+        self.sample.descriptor = {"PFS": 1}
+        self.sample.name = "Sample123"
+        self.data = MagicMock()
+        self.data.id = 12345
+        self.data.output.__getitem__.side_effect = {
+            "species": "Homo sapiens",
+            "source": "ENSEMBL",
+            "exp_type": "TPM",
+        }.__getitem__
+        self.collection = MagicMock()
         self.collection.slug = "slug"
         self.collection.name = "Name"
-        self.collection.samples.count.return_value = 1
-        self.collection.samples.iterate.return_value = [self.sample]
-        self.resolwe = MagicMock(spec=Resolwe)
+        self.collection.samples.filter = self.web_request([self.sample])
+        self.collection.data.filter = self.web_request([self.data])
+        self.resolwe = MagicMock()
+        self.resolwe.url = "https://server.com"
         self.collection.resolwe = self.resolwe
-        self.table_samples = [
-            MagicMock(
-                spec=_TableSample,
-                sample_slug=str(i),
-                expression_files={TPM: f"{i}/tpm.csv", COUNTS: f"{i}/counts.csv"},
-                metadata={"sample_slug": str(i), "PFS": i ** 2},
-            )
-            for i in range(3)
-        ]
         self.metadata_df = pd.DataFrame(
             [[0], [1], [4]], index=["0", "1", "2"], columns=["PFS"]
         )
-        self.metadata_df.index.name = "sample_slug"
         self.expressions_df = pd.DataFrame(
             [[0, 1, 2], [1, 2, 3], [2, 3, 4]],
             index=["0", "1", "2"],
-            columns=["GA", "GB", "GC"],
+            columns=["ENSG001", "ENSG002", "ENSG003"],
         )
-        self.expressions_df.index.name = "sample_slug"
-        self.ensembl_ids = ["ENSG001", "ENSG002", "ENSG003"]
         self.gene_map = {"ENSG001": "GA", "ENSG002": "GB", "ENSG003": "GC"}
 
-    @patch("resdk.collection_tables.default_cache_dir")
+    @staticmethod
+    def web_request(return_value):
+        def slow(*args, **kwargs):
+            sleep(0.1)
+            return return_value
+
+        return slow
+
+    @patch(
+        "resdk.collection_tables.cache_dir_resdk", MagicMock(return_value="/tmp/resdk/")
+    )
     @patch("os.path.exists")
-    def test_init(self, exists_mock, cache_mock):
-        cache_mock.return_value = "/tmp/resdk/"
+    def test_init(self, exists_mock):
         ct = CollectionTables(self.collection)
 
         self.assertIs(ct.collection, self.collection)
@@ -59,300 +68,259 @@ class TestCollectionTables(unittest.TestCase):
         self.assertEqual(ct.cache_dir, "/tmp/cache_dir/")
         exists_mock.assert_called_with("/tmp/cache_dir/")
 
-        # using collection with no samples should rise error
-        self.collection.samples.count.return_value = 0
+    @patch.object(CollectionTables, "_load_fetch")
+    def test_meta(self, load_mock):
+        load_mock.side_effect = self.web_request(self.metadata_df)
+
+        ct = CollectionTables(self.collection)
+        t = time()
+        meta = ct.meta
+        self.assertTrue(time() - t > 0.1)
+        self.assertIs(meta, self.metadata_df)
+        load_mock.assert_called_with(META)
+
+        # use cache
+        t = time()
+        meta = ct.meta
+        self.assertTrue(time() - t < 0.1)
+        self.assertIs(meta, self.metadata_df)
+
+    @patch.object(CollectionTables, "_load_fetch")
+    def test_exp(self, load_mock):
+        load_mock.side_effect = self.web_request(self.expressions_df)
+
+        ct = CollectionTables(self.collection)
+        t = time()
+        exp = ct.exp
+        self.assertTrue(time() - t > 0.1)
+        self.assertIs(exp, self.expressions_df)
+        load_mock.assert_called_with(EXP)
+        self.assertListEqual(ct.gene_ids, ["ENSG001", "ENSG002", "ENSG003"])
+
+        # use cache
+        t = time()
+        exp = ct.exp
+        self.assertTrue(time() - t < 0.1)
+        self.assertIs(exp, self.expressions_df)
+
+    @patch.object(CollectionTables, "_load_fetch")
+    def test_rc(self, load_mock):
+        load_mock.side_effect = self.web_request(self.expressions_df)
+
+        ct = CollectionTables(self.collection)
+        t = time()
+        rc = ct.rc
+        self.assertTrue(time() - t > 0.1)
+        self.assertIs(rc, self.expressions_df)
+        load_mock.assert_called_with(RC)
+        self.assertListEqual(ct.gene_ids, ["ENSG001", "ENSG002", "ENSG003"])
+
+        # use cache
+        t = time()
+        rc = ct.rc
+        self.assertTrue(time() - t < 0.1)
+        self.assertIs(rc, self.expressions_df)
+
+    @patch.object(CollectionTables, "_mapping")
+    def test_id_to_symbol(self, mapping_mock):
+        mapping_mock.side_effect = self.web_request(self.gene_map)
+
+        ct = CollectionTables(self.collection)
         with self.assertRaises(ValueError):
-            CollectionTables(self.collection)
-
-    def test_modified(self):
-        sample_datetime = datetime(2020, 11, 1, 12, 15, 0, 0, tzinfo=pytz.UTC)
-        self.sample.modified = sample_datetime
+            mapping = ct.id_to_symbol
 
         ct = CollectionTables(self.collection)
-        self.assertEqual(ct.modified, sample_datetime)
-
-        # check if the newest
-        self.collection.samples.iterate.return_value = [
-            MagicMock(spec=Sample, modified=sample_datetime + timedelta(minutes=5 * i))
-            for i in range(3)
-        ]
-        ct = CollectionTables(self.collection)
-        self.assertEqual(
-            ct.modified, datetime(2020, 11, 1, 12, 25, 0, 0, tzinfo=pytz.UTC)
+        ct.gene_ids = ["ENSG001", "ENSG002", "ENSG003"]
+        t = time()
+        mapping = ct.id_to_symbol
+        self.assertTrue(time() - t > 0.1)
+        mapping_mock.assert_called_with(
+            ["ENSG001", "ENSG002", "ENSG003"], "ENSEMBL", "Homo sapiens"
         )
+        self.assertIs(mapping, self.gene_map)
 
-        # datetime should transform into UTC
-        self.collection.samples.iterate.return_value = [
-            MagicMock(
-                spec=Sample,
-                modified=sample_datetime.astimezone(pytz.timezone("Europe/Ljubljana")),
-            )
-        ]
+        # test if use case works
+        new_exp = self.expressions_df.rename(columns=ct.id_to_symbol)
+        self.assertListEqual(new_exp.columns.tolist(), ["GA", "GB", "GC"])
+
+        # use cache
+        t = time()
+        mapping = ct.id_to_symbol
+        self.assertTrue(time() - t < 0.1)
+        self.assertIs(mapping, self.gene_map)
+
+    @patch("resdk.collection_tables.clear_cache_dir_resdk")
+    def test_clear_cache(self, clear_mock):
+        CollectionTables.clear_cache()
+        clear_mock.assert_called()
+
+    def test_metadata_version(self):
         ct = CollectionTables(self.collection)
-        self.assertEqual(ct.modified, sample_datetime)
+        version = ct._metadata_version
+        self.assertEqual(version, "2020-11-01T12:15:00Z")
 
-        # modified should be calculated only once
-        self.collection.samples.iterate.reset_mock()
+        # use cache
+        t = time()
+        version = ct._metadata_version
+        self.assertTrue(time() - t < 0.1)
+
+        self.collection.samples.filter = MagicMock(return_value=[])
+        ct1 = CollectionTables(self.collection)
+        with self.assertRaises(ValueError):
+            version = ct1._metadata_version
+
+    def test_expressions_version(self):
         ct = CollectionTables(self.collection)
-        _ = ct.modified
-        self.collection.samples.iterate.assert_called_once()
-        _ = ct.modified
-        self.collection.samples.iterate.assert_called_once()
+        version = ct._expression_version
+        self.assertEqual(version, str(hash(tuple([12345]))))
 
-    @patch("resdk.collection_tables.load_cache")
-    @patch("resdk.collection_tables.save_cache")
-    @patch.object(CollectionTables, "_get_metadata")
-    def test_metadata(self, get_mock, save_mock, load_mock):
-        get_mock.return_value = self.metadata_df
-        load_mock.return_value = None
+        # use cache
+        t = time()
+        version = ct._expression_version
+        self.assertTrue(time() - t < 0.1)
 
+        self.collection.data.filter = MagicMock(return_value=[])
         ct = CollectionTables(self.collection)
-        return_meta = ct.metadata()
+        with self.assertRaises(ValueError):
+            version = ct._expression_version
 
-        load_mock.assert_called_once()
-        load_mock.assert_called_once_with(ANY, ANY, META, ANY)
-        get_mock.assert_called_once()
-        save_mock.assert_called_once()
-        save_mock.assert_called_once_with(self.metadata_df, ANY, ANY, META, ANY)
-        self.assertIs(return_meta, self.metadata_df)
-
-        # test cache behavior
-        load_mock.reset_mock()
-        load_mock.return_value = self.metadata_df
-        get_mock.reset_mock()
-
-        ct = CollectionTables(self.collection)
-        return_meta = ct.metadata()
-        # if on disk don't fetch from web
-        load_mock.assert_called_once()
-        get_mock.assert_not_called()
-        self.assertIs(return_meta, self.metadata_df)
-
-        load_mock.reset_mock()
-        return_meta = ct.metadata()
-        # if in memory don't load from disk
-        load_mock.assert_not_called()
-        get_mock.assert_not_called()
-        self.assertIs(return_meta, self.metadata_df)
-
-    @patch.object(CollectionTables, "_table_samples", new_callable=PropertyMock)
-    def test_get_metadata(self, samples_mock):
-        samples_mock.return_value = self.table_samples
-        ct = CollectionTables(self.collection)
-        metadata = ct._get_metadata()
-        assert_frame_equal(metadata, self.metadata_df)
-
-    @patch.object(CollectionTables, "_get_table_samples")
-    def test_table_samples(self, get_mock):
-        get_mock.return_value = self.table_samples
-
-        ct = CollectionTables(self.collection)
-        return_samples = ct._table_samples
-        get_mock.assert_called_once()
-        self.assertListEqual(return_samples, self.table_samples)
-
-        # fetch table samples only once
-        return_samples = ct._table_samples
-        get_mock.assert_called_once()
-        self.assertListEqual(return_samples, self.table_samples)
-
-    def test_get_table_samples(self):
-        def files(field_name=None):
-            if field_name == TPM:
-                return ["tpm.csv"]
-            elif field_name == COUNTS:
-                return ["counts.csv"]
-            else:
-                raise Exception
-
-        files_mock = MagicMock(side_effect=files)
-        expression_mock = MagicMock(spec=Data, id=123, files=files_mock)
-        self.sample.get_expression.return_value = expression_mock
-        self.sample.descriptor = {"PFS": 42}
-        self.sample.slug = "sample_42"
-
-        ct = CollectionTables(self.collection)
-        table_samples = ct._get_table_samples()
-        self.assertEqual(len(table_samples), 1)
-        self.assertIsInstance(table_samples[0], _TableSample)
-        self.assertEqual(
-            table_samples[0].metadata, {"sample_slug": "sample_42", "PFS": 42}
-        )
-        self.assertEqual(table_samples[0].sample_slug, "sample_42")
-        self.assertEqual(table_samples[0].expression_files[TPM], "123/tpm.csv")
-        self.assertEqual(table_samples[0].expression_files[COUNTS], "123/counts.csv")
-
-        # raise exception on sample with no expression data
-        self.sample.get_expression = MagicMock(side_effect=LookupError)
-        ct = CollectionTables(self.collection)
-        with self.assertRaisesRegex(LookupError, "Sample sample_42 *"):
-            ct._get_table_samples()
-
-        # check for multiple expression files
-        self.sample.get_expression = MagicMock(spec=Data)
-        self.sample.get_expression.return_value.files.return_value = [1, 2, 3]
-        ct = CollectionTables(self.collection)
-        with self.assertRaisesRegex(AssertionError, "Multiple expression files *"):
-            ct._get_table_samples()
-
-    @patch("resdk.collection_tables.load_cache")
-    @patch("resdk.collection_tables.save_cache")
+    @patch(
+        "resdk.collection_tables.cache_dir_resdk", MagicMock(return_value="/tmp/resdk/")
+    )
+    @patch("resdk.collection_tables.load_pickle")
+    @patch("resdk.collection_tables.save_pickle")
+    @patch.object(CollectionTables, "_download_metadata")
     @patch.object(CollectionTables, "_download_expressions")
-    def test_expressions(self, download_mock, save_mock, load_mock):
-        download_mock.return_value = self.expressions_df
+    def test_load_fetch(self, exp_mock, mata_mock, save_mock, load_mock):
+        exp_mock.return_value = self.expressions_df
+        mata_mock.return_value = self.metadata_df
         load_mock.return_value = None
 
         ct = CollectionTables(self.collection)
-        return_expression = ct.expressions()
+        data = ct._load_fetch(META)
+        self.assertIs(data, self.metadata_df)
+        save_mock.assert_called_with(
+            self.metadata_df, "/tmp/resdk/slug_meta_2020-11-01T12:15:00Z.pickle"
+        )
 
-        load_mock.assert_called_once()
-        load_mock.assert_called_once_with(ANY, ANY, TPM, ANY)
-        download_mock.assert_called_once()
-        save_mock.assert_called_once()
-        save_mock.assert_called_once_with(self.expressions_df, ANY, ANY, TPM, ANY)
-        self.assertIs(return_expression, self.expressions_df)
+        save_mock.reset_mock()
+        data = ct._load_fetch(EXP)
+        self.assertIs(data, self.expressions_df)
+        exp_mock.assert_called_with(EXP)
+        save_mock.assert_called_with(
+            self.expressions_df, f"/tmp/resdk/slug_exp_{str(hash((12345,)))}.pickle"
+        )
 
-        # if on disk don't fetch from web
-        load_mock.reset_mock()
+        exp_mock.reset_mock()
+        save_mock.reset_mock()
+        data = ct._load_fetch(RC)
+        self.assertIs(data, self.expressions_df)
+        exp_mock.assert_called_with(RC)
+        save_mock.assert_called_with(
+            self.expressions_df, f"/tmp/resdk/slug_rc_{str(hash((12345,)))}.pickle"
+        )
+
+        exp_mock.reset_mock()
         load_mock.return_value = self.expressions_df
-        download_mock.reset_mock()
+        data = ct._load_fetch(EXP)
+        self.assertIs(data, self.expressions_df)
+        exp_mock.assert_not_called()
+
+    def test_download_metadata(self):
+        ct = CollectionTables(self.collection)
+        meta = ct._download_metadata()
+        expected_meta = pd.DataFrame([1], columns=["PFS"], index=["Sample123"])
+        expected_meta.index.name = "sample_name"
+        assert_frame_equal(meta, expected_meta)
+
+    def test_expression_file_url(self):
+        self.data.files.return_value = ["exp_file.csv"]
 
         ct = CollectionTables(self.collection)
-        return_expression = ct.expressions()
+        file_url = ct._expression_file_url(self.data, EXP)
+        self.assertEqual(file_url, "https://server.com/data/12345/exp_file.csv")
 
-        load_mock.assert_called_once()
-        download_mock.assert_not_called()
-        self.assertIs(return_expression, self.expressions_df)
+        self.data.files.return_value = []
+        with self.assertRaises(LookupError):
+            file_url = ct._expression_file_url(self.data, EXP)
 
-        # use preprocessor
-        preprocessor_mock = MagicMock(side_effect=lambda x: x + 1)
+        self.data.files.return_value = ["exp_file1.csv", "exp_file2.csv"]
+        with self.assertRaises(LookupError):
+            file_url = ct._expression_file_url(self.data, EXP)
+
+    @patch("resdk.collection_tables.BytesIO", MagicMock)
+    @patch.object(CollectionTables, "_expression_file_url", MagicMock)
+    @patch("pandas.read_csv")
+    def test_download_expressions(self, pandas_mock):
+        exp_df = pd.DataFrame(
+            [["ENSG001", 0], ["ENSG002", 1], ["ENSG003", 2]],
+            columns=["Gene", "Expression"],
+        )
+        pandas_mock.return_value = exp_df
+        return_exp = pd.DataFrame(
+            [[0, 1, 2]], columns=["ENSG001", "ENSG002", "ENSG003"], index=["Sample123"]
+        )
+        return_exp.index.name = "sample_name"
+        return_exp.columns.name = "Ensembl"
+        self.data._original_values.__getitem__.side_effect = {
+            "entity": {"name": "Sample123"}
+        }.__getitem__
         ct = CollectionTables(self.collection)
-        return_expression = ct.expressions(preprocess=preprocessor_mock)
-        preprocessor_mock.assert_called_once()
-        assert_frame_equal(return_expression, preprocessor_mock(self.expressions_df))
+        exp = ct._download_expressions(EXP)
+        assert_frame_equal(exp, return_exp)
+        self.assertEqual(exp.attrs["exp_type"], "TPM")
 
-        # cache in memory
-        load_mock.reset_mock()
-        preprocessor_mock.reset_mock()
-        return_cache_expression = ct.expressions(preprocess=preprocessor_mock)
-        load_mock.assert_not_called()
-        preprocessor_mock.assert_not_called()
-        download_mock.assert_not_called()
-        self.assertIs(return_cache_expression, return_expression)
-
-    @patch("resdk.collection_tables.load_cache")
-    @patch("resdk.collection_tables.save_cache")
-    @patch.object(CollectionTables, "_download_expressions")
-    def test_counts(self, download_mock, save_mock, load_mock):
-        download_mock.return_value = self.expressions_df
+    @patch(
+        "resdk.collection_tables.cache_dir_resdk", MagicMock(return_value="/tmp/resdk/")
+    )
+    @patch("resdk.collection_tables.load_pickle")
+    @patch("resdk.collection_tables.save_pickle")
+    @patch.object(CollectionTables, "_download_mapping")
+    def test_mapping(self, download_mock, save_mock, load_mock):
         load_mock.return_value = None
+        download_mock.return_value = self.gene_map
 
         ct = CollectionTables(self.collection)
-        return_counts = ct.counts()
+        mapping = ct._mapping(
+            ["ENSG001", "ENSG002", "ENSG003"], "ENSEMBL", "Homo sapiens"
+        )
+        self.assertDictEqual(mapping, self.gene_map)
+        self.assertListEqual(
+            sorted(download_mock.call_args[0][0]), ["ENSG001", "ENSG002", "ENSG003"]
+        )
+        save_mock.assert_called_with(
+            self.gene_map, "/tmp/resdk/ENSEMBL_Homo sapiens.pickle", override=True
+        )
 
-        load_mock.assert_called_once()
-        load_mock.assert_called_once_with(ANY, ANY, COUNTS, ANY)
-        download_mock.assert_called_once()
-        save_mock.assert_called_once()
-        save_mock.assert_called_once_with(self.expressions_df, ANY, ANY, COUNTS, ANY)
-        self.assertIs(return_counts, self.expressions_df)
-
-        # test cache behavior
-        load_mock.reset_mock()
-        load_mock.return_value = self.metadata_df
+        # download only missing values
         download_mock.reset_mock()
+        load_mock.return_value = {"ENSG002": "GB", "ENSG003": "GC"}
+        mapping = ct._mapping(
+            ["ENSG001", "ENSG002", "ENSG003"], "ENSEMBL", "Homo sapiens"
+        )
+        self.assertDictEqual(mapping, self.gene_map)
+        self.assertListEqual(sorted(download_mock.call_args[0][0]), ["ENSG001"])
 
-        ct = CollectionTables(self.collection)
-        return_counts = ct.counts()
-        # if on disk don't fetch from web
-        load_mock.assert_called_once()
-        download_mock.assert_not_called()
-        self.assertIs(return_counts, self.metadata_df)
-
-        load_mock.reset_mock()
-        return_counts = ct.counts()
-        # if in memory don't load from disk
-        load_mock.assert_not_called()
-        download_mock.assert_not_called()
-        self.assertIs(return_counts, self.metadata_df)
-
-    @patch.object(CollectionTables, "_get_gene_map")
-    def test_gene_map(self, get_mock):
-        get_mock.return_value = self.gene_map
-
-        ct = CollectionTables(self.collection)
-        return_map = ct._gene_map(self.ensembl_ids)
-        get_mock.assert_called_once()
-        get_mock.assert_called_once_with(self.ensembl_ids)
-        self.assertDictEqual(return_map, self.gene_map)
-
-        # fetch gene map only once
-        return_map = ct._gene_map(self.ensembl_ids)
-        get_mock.assert_called_once()
-        self.assertDictEqual(return_map, self.gene_map)
-
-    @patch.object(CollectionTables, "_table_samples")
-    def test_get_gene_map(self, sample_mock):
+    def test_download_mapping(self):
         def create_feature(fid, name):
-            m = MagicMock(spec=Feature, feature_id=fid)
+            m = MagicMock(feature_id=fid)
             # name can't be set on initialization
             m.name = name
             return m
 
-        sample_mock.__getitem__().metadata = {"general": {"species": "Homo sapiens"}}
         self.resolwe.feature.filter.return_value = [
             create_feature(fid, name) for fid, name in self.gene_map.items()
         ]
 
         ct = CollectionTables(self.collection)
-        return_map = ct._get_gene_map(self.ensembl_ids)
+        mapping = ct._download_mapping(
+            ["ENSG001", "ENSG002", "ENSG003"], "ENSEMBL", "Homo sapiens"
+        )
 
         self.resolwe.feature.filter.assert_called_once()
         self.resolwe.feature.filter.assert_called_once_with(
-            species="Homo sapiens", feature_id__in=self.ensembl_ids
+            source="ENSEMBL",
+            species="Homo sapiens",
+            feature_id__in=["ENSG001", "ENSG002", "ENSG003"],
         )
-        self.assertDictEqual(return_map, self.gene_map)
-
-    @patch.object(CollectionTables, "_gene_map")
-    def test_gene_mapping(self, map_mock):
-        map_mock.return_value = self.gene_map
-        pre_map_df = self.expressions_df.copy()
-        pre_map_df.columns = self.ensembl_ids
-
-        ct = CollectionTables(self.collection)
-        mapped_df = ct._gene_mapping(pre_map_df)
-        assert_frame_equal(mapped_df, self.expressions_df)
-
-    @patch("resdk.collection_tables.BytesIO", MagicMock)
-    @patch(
-        "pandas.read_csv",
-        MagicMock(
-            side_effect=[
-                pd.DataFrame(
-                    [["GA", 0 + i], ["GB", 1 + i], ["GC", 2 + i]],
-                    columns=["Gene", "Expression"],
-                )
-                for i in range(3)
-            ]
-        ),
-    )
-    @patch.object(CollectionTables, "_table_samples", new_callable=PropertyMock)
-    @patch.object(CollectionTables, "_gene_mapping", new_callable=PropertyMock)
-    def test_download_expressions(self, map_mock, sample_mock):
-        map_mock.return_value = lambda x: x
-        sample_mock.return_value = self.table_samples
-        self.resolwe.url = "https://server.com"
-        self.resolwe.auth = MagicMock()
-        get_mock = MagicMock(return_value=MagicMock())
-        self.resolwe.session.get = get_mock
-
-        ct = CollectionTables(self.collection)
-        expression_df = ct._download_expressions(TPM)
-
-        get_calls = [
-            call("https://server.com/data/0/tpm.csv", auth=ANY),
-            call("https://server.com/data/1/tpm.csv", auth=ANY),
-            call("https://server.com/data/2/tpm.csv", auth=ANY),
-        ]
-        get_mock.assert_has_calls(get_calls)
-        assert_frame_equal(expression_df, self.expressions_df)
+        self.assertDictEqual(mapping, self.gene_map)

--- a/tests/unit/test_tables_cache.py
+++ b/tests/unit/test_tables_cache.py
@@ -1,97 +1,82 @@
 import unittest
-from datetime import datetime
 
 import pandas as pd
-import pytz
-from mock import MagicMock, patch
+from mock import ANY, MagicMock, patch
 
 from resdk.utils.table_cache import (
-    _full_cache_file,
-    default_cache_dir,
-    load_cache,
-    save_cache,
+    cache_dir_resdk,
+    cache_dir_resdk_base,
+    clear_cache_dir_resdk,
+    load_pickle,
+    save_pickle,
 )
 
 
 class TestCache(unittest.TestCase):
-    @patch("resdk.utils.table_cache.__version__", "0.0.0")
-    def test_default_cache_dir(self):
+    def test_cache_dir_resdk_base(self):
+        for platform in ["darwin", "win32", "posix"]:
+            with patch("sys.platform", platform):
+                self.assertTrue(cache_dir_resdk_base().endswith("ReSDK"))
+
+    @patch("resdk.utils.table_cache.__version__", "0.0.0.dev0+g0d51338")
+    def test_cache_dir_resdk(self):
         with patch("sys.platform", "darwin"):
-            self.assertTrue(default_cache_dir().endswith("Library/Caches/ReSDK/0.0.0"))
+            self.assertTrue(
+                cache_dir_resdk().endswith("Library/Caches/ReSDK/0.0.0.dev")
+            )
 
         with patch("sys.platform", "win32"):
             self.assertTrue(
-                default_cache_dir().endswith("AppData/Local/ReSDK/0.0.0/Cache")
+                cache_dir_resdk().endswith("AppData/Local/ReSDK/0.0.0.dev/Cache")
             )
 
         with patch("sys.platform", "posix"):
-            self.assertTrue(default_cache_dir().endswith(".cache/ReSDK/0.0.0"))
+            self.assertTrue(cache_dir_resdk().endswith(".cache/ReSDK/0.0.0.dev"))
 
-    def test_full_cache_file(self):
-        dt = datetime(2020, 11, 1, 12, 15, 30, 123456, pytz.UTC)
-        path = _full_cache_file("/tmp/", "coll_slug", "dtype", dt)
-        self.assertEqual(
-            path, "/tmp/coll_slug_dtype_2020-11-01T12:15:30.123456+00:00.pickle"
-        )
+    @patch("resdk.utils.table_cache.cache_dir_resdk_base")
+    @patch("resdk.utils.table_cache.rmtree")
+    @patch("os.path.exists", MagicMock(return_value=True))
+    def test_clear_cache(self, rm_mock, dir_mock):
+        dir_mock.return_value = "/tmp/resdk/"
+        clear_cache_dir_resdk()
+        rm_mock.assert_called_with("/tmp/resdk/")
 
     @patch("os.path.exists")
-    @patch("pandas.read_pickle")
-    def test_load_cache(self, read_mock, path_mock):
+    @patch("pickle.load")
+    @patch("resdk.utils.table_cache.open", MagicMock())
+    def test_load_pickle(self, pickle_mock, path_mock):
         # load existing cache file
         path_mock.return_value = True
         table_mock = MagicMock(spec=pd.DataFrame)
-        read_mock.return_value = table_mock
-        table = load_cache(
-            "/tmp/", "coll_slug", "dtype", datetime(2020, 11, 1, 12, 0, 0, 0, pytz.UTC)
-        )
+        pickle_mock.return_value = table_mock
+        table = load_pickle("pickle_file_path.pickle")
 
-        path_mock.assert_called_with(
-            "/tmp/coll_slug_dtype_2020-11-01T12:00:00+00:00.pickle"
-        )
-        read_mock.assert_called_with(
-            "/tmp/coll_slug_dtype_2020-11-01T12:00:00+00:00.pickle"
-        )
+        path_mock.assert_called_with("pickle_file_path.pickle")
         self.assertIs(table, table_mock)
 
         # return None for non-existing cache
-        read_mock.reset_mock()
+        pickle_mock.reset_mock()
         path_mock.return_value = False
-        table = load_cache(
-            "/tmp/", "coll_slug", "dtype", datetime(2020, 11, 1, 12, 0, 0, 0, pytz.UTC)
-        )
-        read_mock.assert_not_called()
+        table = load_pickle("pickle_file_path.pickle")
+        pickle_mock.assert_not_called()
         self.assertIsNone(table)
 
     @patch("os.path.exists")
-    def test_save_cache(self, path_mock):
+    @patch("pickle.dump")
+    @patch("resdk.utils.table_cache.open", MagicMock())
+    def test_save_pickle(self, pickle_mock, path_mock):
         # save to cache file if not non-existing
         path_mock.return_value = False
         table_mock = MagicMock(spec=pd.DataFrame)
-        to_mock = table_mock.to_pickle
-        save_cache(
-            table_mock,
-            "/tmp/",
-            "coll_slug",
-            "dtype",
-            datetime(2020, 11, 1, 12, 0, 0, 0, pytz.UTC),
-        )
+        save_pickle(table_mock, "pickle_file_path.pickle")
 
-        path_mock.assert_called_with(
-            "/tmp/coll_slug_dtype_2020-11-01T12:00:00+00:00.pickle"
-        )
-        to_mock.assert_called_with(
-            "/tmp/coll_slug_dtype_2020-11-01T12:00:00+00:00.pickle"
-        )
+        path_mock.assert_called_with("pickle_file_path.pickle")
+        pickle_mock.assert_called_with(table_mock, ANY)
 
-        # don't save if cache file exists
-        to_mock.reset_mock()
+        pickle_mock.reset_mock()
         path_mock.return_value = True
-        save_cache(
-            table_mock,
-            "/tmp/",
-            "coll_slug",
-            "dtype",
-            datetime(2020, 11, 1, 12, 0, 0, 0, pytz.UTC),
-        )
+        save_pickle(table_mock, "pickle_file_path.pickle")
+        pickle_mock.assert_not_called()
 
-        to_mock.assert_not_called()
+        save_pickle(table_mock, "pickle_file_path.pickle", override=True)
+        pickle_mock.assert_called_with(table_mock, ANY)


### PR DESCRIPTION
What started with just a few fixes ended up being closer to a rewrite.
The major changes are:
 * change main methods to attributes: `metadata()` -> `meta`, `expressions()` -> `exp`, `counts()` -> `rc`
 * add `clear_cache()` which removes all cache files from the default location
 * add method `id_to_symbol` which holds gene id to symbole mapping
 * `exp` and `rc` return gene ids instead of symboles
 * sample name is used instead of sample slug for tables index
 * add separate versioning for expression data
 * seperatly fetch metadata and expressions
 * add downloading progress bar
 * mapping of gene ids to symboles is now cached on disc and is also used on other collection
 * add `CollectionTable` to `resdk` namespace
 * store expression type in returned tables `attrs['exp_type']` attribute

Performance on 45 samples (`exp` and `rc` have the same performance):
| how  | what | old | new |
|--------|--------|------|-------|
| / | init | 0.4s | <0.01s |
| uncached | meta | 127s* | 1.7s |
| uncached | exp | 255s* | 64s** |
| uncached | id_to_symbol | / | 86s |
| cached | meta | 1.7s | 0.4s |
| cached | exp | 0.02s | 1.8s |
| cached | id_to_symbol | / | 2.8s |

\* calling just one of `metadata()` or `expressions()`, if used together resolwe server gets queried only once and performance improves for he second function for ~120s
** without gene id to symbol mapping