### PR TITLE
Fix misordered meta and expression data index

### DIFF
--- a/src/resdk/collection_tables.py
+++ b/src/resdk/collection_tables.py
@@ -502,6 +502,7 @@ class CollectionTables:
             how = "right" if meta.columns.empty else "outer"
             meta = meta.merge(orange_data, how=how, left_index=True, right_index=True)
 
+        meta = meta.sort_index()
         meta.index.name = "sample_name"
 
         return meta


### PR DESCRIPTION
Fixes #250 
Somewhere along the way of improving and extending CollectionTables functionality, we lost the sorting of indexes in metadata which makes `ct.exp` and `ct.meta` have different ordered samples.