### PR TITLE
Enable ReSDK Tables to cache also very large collections

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,16 @@ All notable changes to this project are documented in this file.
 
 
 ===================
+13.5.1 - 2021-09-16
+===================
+
+Fixed
+-----
+- Fix ReSDK Tables so they can cache also very large collections
+  (greater than 4Gb in memory)
+
+
+===================
 13.5.0 - 2021-09-13
 ===================
 

--- a/src/resdk/utils/table_cache.py
+++ b/src/resdk/utils/table_cache.py
@@ -60,7 +60,7 @@ def load_pickle(pickle_file: str) -> Any:
     """
     if os.path.exists(pickle_file):
         with open(pickle_file, "rb") as handle:
-            return pickle.load(handle)
+            return pickle.load(handle, protocol=pickle.HIGHEST_PROTOCOL)
 
 
 def save_pickle(obj: Any, pickle_file: str, override=False) -> None:
@@ -73,4 +73,4 @@ def save_pickle(obj: Any, pickle_file: str, override=False) -> None:
     """
     if not os.path.exists(pickle_file) or override:
         with open(pickle_file, "wb") as handle:
-            pickle.dump(obj, handle)
+            pickle.dump(obj, handle, protocol=pickle.HIGHEST_PROTOCOL)

--- a/tests/unit/test_tables_cache.py
+++ b/tests/unit/test_tables_cache.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 import pandas as pd
@@ -71,7 +72,9 @@ class TestCache(unittest.TestCase):
         save_pickle(table_mock, "pickle_file_path.pickle")
 
         path_mock.assert_called_with("pickle_file_path.pickle")
-        pickle_mock.assert_called_with(table_mock, ANY)
+        pickle_mock.assert_called_with(
+            table_mock, ANY, protocol=pickle.HIGHEST_PROTOCOL
+        )
 
         pickle_mock.reset_mock()
         path_mock.return_value = True
@@ -79,4 +82,6 @@ class TestCache(unittest.TestCase):
         pickle_mock.assert_not_called()
 
         save_pickle(table_mock, "pickle_file_path.pickle", override=True)
-        pickle_mock.assert_called_with(table_mock, ANY)
+        pickle_mock.assert_called_with(
+            table_mock, ANY, protocol=pickle.HIGHEST_PROTOCOL
+        )


### PR DESCRIPTION
Python 3.6 and 3.7 use protocol 3 by default. We should use protocol 4, since this one allows pickling of objects, larger than 4 Gb.
[More info.](https://docs.python.org/3/library/pickle.html#pickle-protocols)