### PR TITLE
Use integers as id's and all other as slugs in ResolweQuery

### DIFF
--- a/src/resdk/query.py
+++ b/src/resdk/query.py
@@ -255,7 +255,7 @@ class ResolweQuery:
                 )
 
             arg = args[0]
-            kwargs = {"id": arg} if str(arg).isdigit() else {self.slug_field: arg}
+            kwargs = {"id": arg} if isinstance(arg, int) else {self.slug_field: arg}
 
         if self.slug_field in kwargs:
             if issubclass(self.resource, (Process, DescriptorSchema)):


### PR DESCRIPTION
This fixes the issue when slug is completely numeric. In such case,
slug is falsely interpreted as id.