### PR TITLE
Metadata: Add column if match is in df index, remove matched column

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -17,6 +17,9 @@ Fixed
 -----
 - Fix parsing of new metadata format in ``resdk.tables.BaseTables.meta``
 
+Changed
+-------
+- ``Metadata.set_index(df)`` add column if sample name / slug is in ``df`` index
 
 ===================
 14.1.0 - 2022-03-25

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -73,8 +73,14 @@ than call ``save()``::
 
     m = Metadata(resolwe=<resolwe>)
     m.collection = <my-collection>
-    m.df = <my-df>
+    my_df = m.set_index(<my-df>)
+    m.df = my_df
     m.save()
+
+where ``m.set_index(<my-df>)`` is a helper function that finds ``Sample name/slug/ID``
+column or index name, maps it to ``Sample ID`` and sets it as index.
+This function is recommended to use because the validation step is trying to
+match ``m.df`` index with ``m.collection`` sample ID's.
 
 Deleting Metadata works the same as for any other resource. Be careful,
 this cannot be undone and you need to have sufficient permissions::

--- a/src/resdk/resources/metadata.py
+++ b/src/resdk/resources/metadata.py
@@ -89,9 +89,19 @@ class Metadata(Data):
         return self._df_bytes
 
     def set_index(self, df):
-        """Set index of df to Sample ID."""
+        """Set index of df to Sample ID.
+
+        If there is a column with ``Sample ID`` just set that as index. If there is
+        ``Sample name`` or ``Sample slug`` column, map sample name / slug to sample ID's
+        and set ID's as an index. If no suitable column in there, raise an error.
+        Works also if any of the above options is already an index with appropriate name.
+        """
         for match_column in self.sample_identifier_columns:
             if match_column in df.columns:
+                break
+            if match_column == df.index.name:
+                # Add new column with index name
+                df[match_column] = df.index
                 break
         else:
             options = ", ".join(self.sample_identifier_columns)

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -92,6 +92,12 @@ class TestMetadata(unittest.TestCase):
         df_out = m.set_index(df)
         pd.testing.assert_frame_equal(self.df, df_out.drop(columns=["Sample name"]))
 
+        # If Sample name is in index, map to sample ID and set that as index
+        df = pd.DataFrame({"Response": ["PD", "CR"], "Sample name": ["S1", "S2"]})
+        df = df.set_index("Sample name")
+        df_out = m.set_index(df)
+        pd.testing.assert_frame_equal(self.df, df_out.drop(columns=["Sample name"]))
+
     def test_validate(self):
         with self.assertRaisesRegex(
             ValueError, "Setting df attribute before setting collection is not allowed."


### PR DESCRIPTION
While I was using Metadata resource I got some ideas how this resource could be improved. In this PR I added three things:

- Usually, `Sample name/slug/ID` is already set as index and `m.set_index(<df>)` could just map it to `Sample ID`.
- `m.set_index(<df>)` could also delete `Sample name/slug/ID` column since it is not needed anymore. The same as `DataFrame.set_index` function removes the column.
- Add example with `m.set_index(<df>)` function in the documentation.

These are generally just ideas and if somebody else can find them useful then I'll be glad if we merge this PR.
