### PR TITLE
Support Python 3.10

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ sphinx:
 formats: all
 
 python:
-  version: 3.7
+  version: 3.10
   install:
     - method: pip
       path: .

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ throttle(["resolwe_bio_py"]) {
                                     // resource indefinitely thus we have to set a timeout on their
                                     // execution time.
                                     timeout(time: 15, unit: "MINUTES") {
-                                        sh "tox -e py39-e2e-resdk ${tox_extra_args}"
+                                        sh "tox -e py310-e2e-resdk ${tox_extra_args}"
                                     }
                                 }
                             }


### PR DESCRIPTION
Switch to Python 3.10 for e2e tests and readthedocs.