### PR TITLE
Fix dowload bug

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -28,7 +28,9 @@ Added
 Fixed
 -----
 - Fix downloading tables data
-
+- Fix download stopped with incomplete data received: urllib3 version 2.0 has 
+  ``enforce_content_length`` set to ``True`` by default which raises error
+  if not enough data was received
 
 ===================
 20.0.0 - 2023-10-27

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ classifiers = [
 dependencies = [
     "aiohttp~=3.8.5",
     "requests>=2.6.0",
+    "urllib3>=2",
     "slumber>=0.7.1",
     "wrapt",
     "pytz>=2018.4",


### PR DESCRIPTION
that caused incomplete downoads without errors when transfer was interrupted. See https://github.com/psf/requests/issues/4956 and https://github.com/urllib3/urllib3/pull/2514/files for details.

This a "temporary fix" for GS-57 : the MD5 checksum must also be checked when download is completed.