### PR TITLE
Replace int64 with nullable Int64 in RNATables

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,12 @@ Added
 - Add ``restart`` method to the ``Data`` resource
 
 
+Fixed
+-----
+- Fix fetching ``RNATables`` for collections with missing MultiQC objects by
+  using nullable integer data type ``Int64`` for integer columns.
+
+
 ===================
 21.1.0 - 2023-02-09
 ===================

--- a/src/resdk/tables/rna.py
+++ b/src/resdk/tables/rna.py
@@ -136,7 +136,7 @@ MQC_GENERAL_COLUMNS = [
     {
         "name": "STAR quantification_mqc-generalstats-star_quantification-Assigned_reads",
         "slug": "star_assigned_reads",
-        "type": "int64",
+        "type": "Int64",
         "agg_func": "sum",
     },
     {


### PR DESCRIPTION
Calling RNATables.qc would fail with `Cannot convert non-finite values (NA or inf) to integer: Error while type casting for column 'star_assigned_reads'` in cases where MultiQC data is not available for a subset of samples. 

All other integer columns use `Int64` dtype which supports missing values (https://pandas.pydata.org/docs/user_guide/integer_na.html).